### PR TITLE
Implement OG and Twitter meta support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Planned
+- **0.3.0**: Template polish, description fallback order, preview card.
+- **1.0.0**: Stable release – OG + JSON-LD parity, diagnostics.
+- **2.0.0**: AI Assist module (OpenAI) for titles/descriptions/keywords.
+
+## [0.2.0] - 2025-09-24
+### Added
+- Open Graph and Twitter Card emission driven by the shared context provider with hero/fallback image resolution.
+- Admin settings toggles for Open Graph and Twitter metadata, including optional Twitter handle field output and social snapshot on the Debug page.
+- New filters `hr_sa_enable_og`, `hr_sa_enable_twitter`, `hr_sa_og_tags`, and `hr_sa_twitter_tags` for extensibility.
+
+### Changed
+- Context provider now resolves titles, descriptions, countries, and hero images from post data, templates, and plugin settings.
+- Debug interface now surfaces social metadata, resolved values, and emission status alongside existing diagnostics.
+
 ## [0.1.0] - 2025-09-23
 ### Added
 - Initial scaffold for **HR SEO Assistant** plugin.
@@ -17,10 +33,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Notes
 - No OG/Twitter emission yet (planned for 0.2.0).
 - JSON-LD emitters to be adopted from **legacy MUs** in Phase 0 while preserving output parity.
-
-## [Unreleased]
-### Planned
-- **0.2.0**: OG/Twitter emitter (hero → fallback), minimal templates.
-- **0.3.0**: Template polish, description fallback order, preview card.
-- **1.0.0**: Stable release – OG + JSON-LD parity, diagnostics.
-- **2.0.0**: AI Assist module (OpenAI) for titles/descriptions/keywords.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HR SEO Assistant
 
-**Version:** 0.1.0  
+**Version:** 0.2.0
 **Author:** Himalayan Rides  
 **Description:** HR SEO Assistant unifies Open Graph, Twitter Cards, and JSON-LD schema under one modular framework. Built for portability and clarity, it integrates with the HR Media Help hero system and provides a debug page for validation. Future phases will add AI-assisted SEO enhancements.
 
@@ -37,7 +37,7 @@ We follow **semantic versioning**:
 ---
 
 ## Development Notes
-- Hero image integration is provided via `apply_filters('hr_current_hero_url', null)`.
+- Hero image integration is provided via `apply_filters('hr_mh_current_hero_url', null)`.
 - Always provide a fallback image in settings.
 - Debug mode can be enabled in settings to access the debug surface.
 - All metadata is emitted early in `<head>` with no duplicates.

--- a/admin/pages/modules.php
+++ b/admin/pages/modules.php
@@ -27,9 +27,14 @@ function hr_sa_render_modules_page(): void
             'enabled'     => hr_sa_is_jsonld_enabled(),
         ],
         [
-            'name'        => __('OG/Twitter Module', HR_SA_TEXT_DOMAIN),
-            'description' => __('Open Graph and Twitter Cards (planned for Phase 1).', HR_SA_TEXT_DOMAIN),
+            'name'        => __('Open Graph Tags', HR_SA_TEXT_DOMAIN),
+            'description' => __('Generates Open Graph metadata for social sharing.', HR_SA_TEXT_DOMAIN),
             'enabled'     => hr_sa_is_og_enabled(),
+        ],
+        [
+            'name'        => __('Twitter Cards', HR_SA_TEXT_DOMAIN),
+            'description' => __('Outputs summary_large_image cards aligned with Open Graph values.', HR_SA_TEXT_DOMAIN),
+            'enabled'     => hr_sa_is_twitter_enabled(),
         ],
         [
             'name'        => __('Debug Tools', HR_SA_TEXT_DOMAIN),

--- a/admin/pages/overview.php
+++ b/admin/pages/overview.php
@@ -37,7 +37,8 @@ function hr_sa_render_overview_page(): void
                 <p><?php echo esc_html(sprintf(__('Version %s', HR_SA_TEXT_DOMAIN), $version)); ?></p>
                 <ul>
                     <li><?php echo esc_html__('JSON-LD Emitters', HR_SA_TEXT_DOMAIN) . ': ' . (hr_sa_is_jsonld_enabled() ? esc_html__('Enabled', HR_SA_TEXT_DOMAIN) : esc_html__('Disabled', HR_SA_TEXT_DOMAIN)); ?></li>
-                    <li><?php echo esc_html__('OG/Twitter Module', HR_SA_TEXT_DOMAIN) . ': ' . (hr_sa_is_og_enabled() ? esc_html__('Enabled', HR_SA_TEXT_DOMAIN) : esc_html__('Disabled', HR_SA_TEXT_DOMAIN)); ?></li>
+                    <li><?php echo esc_html__('Open Graph Tags', HR_SA_TEXT_DOMAIN) . ': ' . (hr_sa_is_og_enabled() ? esc_html__('Enabled', HR_SA_TEXT_DOMAIN) : esc_html__('Disabled', HR_SA_TEXT_DOMAIN)); ?></li>
+                    <li><?php echo esc_html__('Twitter Cards', HR_SA_TEXT_DOMAIN) . ': ' . (hr_sa_is_twitter_enabled() ? esc_html__('Enabled', HR_SA_TEXT_DOMAIN) : esc_html__('Disabled', HR_SA_TEXT_DOMAIN)); ?></li>
                     <li><?php echo esc_html__('Debug Mode', HR_SA_TEXT_DOMAIN) . ': ' . ($debug_on ? esc_html__('Enabled', HR_SA_TEXT_DOMAIN) : esc_html__('Disabled', HR_SA_TEXT_DOMAIN)); ?></li>
                 </ul>
             </div>

--- a/admin/pages/settings.php
+++ b/admin/pages/settings.php
@@ -21,6 +21,8 @@ function hr_sa_render_settings_page(): void
     }
 
     $fallback      = (string) hr_sa_get_setting('hr_sa_fallback_image', '');
+    $og_enabled    = hr_sa_is_flag_enabled('hr_sa_og_enabled', false);
+    $twitter_cards = hr_sa_is_flag_enabled('hr_sa_twitter_enabled', false);
     $tpl_trip      = (string) hr_sa_get_setting('hr_sa_tpl_trip');
     $tpl_page      = (string) hr_sa_get_setting('hr_sa_tpl_page');
     $brand_suffix  = (bool) hr_sa_get_setting('hr_sa_tpl_page_brand_suffix');
@@ -45,6 +47,24 @@ function hr_sa_render_settings_page(): void
                                 <button type="button" class="button hr-sa-media-picker" data-target="hr_sa_fallback_image"><?php esc_html_e('Choose Image', HR_SA_TEXT_DOMAIN); ?></button>
                             </div>
                             <p class="description"><?php esc_html_e('Used when no hero image is provided. Must be an absolute HTTPS URL.', HR_SA_TEXT_DOMAIN); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Social Metadata', HR_SA_TEXT_DOMAIN); ?></th>
+                        <td>
+                            <fieldset>
+                                <legend class="screen-reader-text"><?php esc_html_e('Social Metadata Toggles', HR_SA_TEXT_DOMAIN); ?></legend>
+                                <label for="hr_sa_og_enabled">
+                                    <input type="checkbox" id="hr_sa_og_enabled" name="hr_sa_og_enabled" value="1" <?php checked($og_enabled); ?> />
+                                    <?php esc_html_e('Enable Open Graph tags', HR_SA_TEXT_DOMAIN); ?>
+                                </label>
+                                <br />
+                                <label for="hr_sa_twitter_enabled">
+                                    <input type="checkbox" id="hr_sa_twitter_enabled" name="hr_sa_twitter_enabled" value="1" <?php checked($twitter_cards); ?> />
+                                    <?php esc_html_e('Enable Twitter Card tags', HR_SA_TEXT_DOMAIN); ?>
+                                </label>
+                                <p class="description"><?php esc_html_e('Twitter Cards reuse Open Graph data and require a large hero image or fallback.', HR_SA_TEXT_DOMAIN); ?></p>
+                            </fieldset>
                         </td>
                     </tr>
                     <tr>

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -73,6 +73,21 @@
     padding-left: 20px;
 }
 
+.hr-sa-meta-status {
+    list-style: disc;
+    padding-left: 20px;
+    margin-top: 0;
+}
+
+.hr-sa-meta-list {
+    list-style: disc;
+    padding-left: 20px;
+}
+
+.hr-sa-meta-list li code {
+    margin-right: 6px;
+}
+
 .hr-sa-copy-json {
     margin-top: 10px;
 }

--- a/core/context.php
+++ b/core/context.php
@@ -18,16 +18,25 @@ if (!defined('ABSPATH')) {
  */
 function hr_sa_get_context(): array
 {
+    $post_id   = is_singular() ? (int) get_queried_object_id() : 0;
+    $type      = hr_sa_detect_content_type();
+    $site_name = hr_sa_context_clean_string((string) hr_sa_get_setting('hr_sa_site_name', get_bloginfo('name')));
+    $site_name = $site_name !== '' ? $site_name : hr_sa_context_clean_string((string) get_bloginfo('name'));
+    $locale    = (string) hr_sa_get_setting('hr_sa_locale', get_locale());
+    $twitter   = (string) hr_sa_get_setting('hr_sa_twitter_handle', '');
+    $image     = hr_sa_resolve_context_image_url($post_id > 0 ? $post_id : null);
+
     $context = [
         'url'            => hr_sa_guess_canonical_url(),
-        'type'           => hr_sa_detect_content_type(),
-        'title'          => '', // TODO: Populate with contextual title in Phase 1.
-        'description'    => '', // TODO: Populate with contextual description in Phase 1.
-        'country'        => '', // TODO: Populate with geographic context in Phase 1.
-        'site_name'      => hr_sa_get_setting('hr_sa_site_name', get_bloginfo('name')),
-        'locale'         => hr_sa_get_setting('hr_sa_locale', get_locale()),
-        'twitter_handle' => hr_sa_get_setting('hr_sa_twitter_handle', ''),
-        'hero_url'       => hr_sa_get_media_help_hero_url(),
+        'type'           => $type,
+        'title'          => hr_sa_resolve_context_title($type, $post_id, $site_name),
+        'description'    => hr_sa_resolve_context_description($type, $post_id, $site_name),
+        'country'        => hr_sa_resolve_context_country($type, $post_id),
+        'site_name'      => $site_name,
+        'locale'         => $locale !== '' ? $locale : get_locale(),
+        'twitter_handle' => $twitter,
+        'hero_url'       => $image,
+        'image'          => $image,
     ];
 
     return apply_filters('hr_sa_get_context', $context);
@@ -39,18 +48,22 @@ function hr_sa_get_context(): array
 function hr_sa_guess_canonical_url(): string
 {
     if (is_front_page() || is_home()) {
-        return trailingslashit(home_url('/'));
+        return trailingslashit(set_url_scheme(home_url('/'), 'https'));
     }
 
     if (is_singular()) {
         $permalink = get_permalink();
         if ($permalink) {
-            return trailingslashit($permalink);
+            return trailingslashit(set_url_scheme($permalink, 'https'));
         }
     }
 
     $current_url = home_url(add_query_arg([]));
-    return is_string($current_url) ? $current_url : trailingslashit(home_url('/'));
+    if (is_string($current_url) && $current_url !== '') {
+        return set_url_scheme($current_url, 'https');
+    }
+
+    return trailingslashit(set_url_scheme(home_url('/'), 'https'));
 }
 
 /**
@@ -71,4 +84,346 @@ function hr_sa_detect_content_type(): string
     }
 
     return 'page';
+}
+
+/**
+ * Resolve a normalized string from potentially formatted content.
+ */
+function hr_sa_context_clean_string(string $text): string
+{
+    $text = wp_strip_all_tags($text, true);
+    $text = html_entity_decode($text, ENT_QUOTES, get_bloginfo('charset') ?: 'UTF-8');
+    $text = (string) preg_replace('/\s+/u', ' ', $text);
+
+    return trim($text);
+}
+
+/**
+ * Condense text and trim to a word boundary.
+ */
+function hr_sa_trim_text(string $text, int $limit = 0): string
+{
+    $clean = hr_sa_context_clean_string($text);
+    if ($clean === '') {
+        return '';
+    }
+
+    if ($limit > 0) {
+        $clean = wp_trim_words($clean, $limit, '…');
+    }
+
+    return $clean;
+}
+
+/**
+ * Apply template replacements and normalize whitespace.
+ *
+ * @param array<string, string> $replacements
+ */
+function hr_sa_apply_template_replacements(string $template, array $replacements): string
+{
+    if ($template === '') {
+        return '';
+    }
+
+    $result = strtr($template, $replacements);
+    $result = (string) preg_replace('/\{\{[^}]+\}\}/', '', $result);
+
+    return hr_sa_context_clean_string($result);
+}
+
+/**
+ * Append a brand suffix to a title if it is not already present.
+ */
+function hr_sa_append_brand_suffix(string $title, string $site_name): string
+{
+    $title = hr_sa_context_clean_string($title);
+    $brand = hr_sa_context_clean_string($site_name);
+
+    if ($brand === '') {
+        return $title;
+    }
+
+    if ($title === '') {
+        return $brand;
+    }
+
+    if (stripos($title, $brand) !== false) {
+        return $title;
+    }
+
+    return $title . ' | ' . $brand;
+}
+
+/**
+ * Resolve comma-separated country names for a trip.
+ */
+function hr_sa_resolve_trip_countries(int $post_id): string
+{
+    $terms = wp_get_post_terms($post_id, 'country', ['fields' => 'names']);
+    if (is_wp_error($terms) || empty($terms)) {
+        return '';
+    }
+
+    $names = array_map('hr_sa_context_clean_string', array_map('strval', $terms));
+    $names = array_values(array_filter($names, static fn(string $name): bool => $name !== ''));
+
+    return $names ? implode(', ', $names) : '';
+}
+
+/**
+ * Build the context title using templates and fallbacks.
+ */
+function hr_sa_resolve_context_title(string $type, int $post_id, string $site_name): string
+{
+    if ($type === 'home') {
+        return $site_name;
+    }
+
+    if ($type === 'trip' && $post_id > 0) {
+        $template = (string) hr_sa_get_setting('hr_sa_tpl_trip', '{{trip_name}} | Motorcycle Tour in {{country}}');
+        $replacements = [
+            '{{trip_name}}' => hr_sa_context_clean_string(get_the_title($post_id) ?: ''),
+            '{{country}}'   => hr_sa_resolve_trip_countries($post_id),
+            '{{site_name}}' => $site_name,
+        ];
+        $title = hr_sa_apply_template_replacements($template, $replacements);
+        if ($title === '') {
+            $title = $replacements['{{trip_name}}'];
+        }
+
+        return $title !== '' ? $title : $site_name;
+    }
+
+    if ($post_id > 0) {
+        $template = (string) hr_sa_get_setting('hr_sa_tpl_page', '{{page_title}}');
+        $replacements = [
+            '{{page_title}}' => hr_sa_context_clean_string(get_the_title($post_id) ?: ''),
+            '{{site_name}}'  => $site_name,
+        ];
+        $title = hr_sa_apply_template_replacements($template, $replacements);
+        if ($title === '') {
+            $title = $replacements['{{page_title}}'];
+        }
+
+        if (hr_sa_get_setting('hr_sa_tpl_page_brand_suffix')) {
+            $title = hr_sa_append_brand_suffix($title, $site_name);
+        }
+
+        return $title !== '' ? $title : $site_name;
+    }
+
+    return $site_name;
+}
+
+/**
+ * Resolve the context description based on content type.
+ */
+function hr_sa_resolve_context_description(string $type, int $post_id, string $site_name): string
+{
+    if ($type === 'home') {
+        $tagline = (string) get_bloginfo('description', 'display');
+        $description = hr_sa_trim_text($tagline, 40);
+
+        return $description !== '' ? $description : $site_name;
+    }
+
+    $candidates = [];
+    if ($post_id > 0) {
+        if ($type === 'trip') {
+            if (function_exists('get_field')) {
+                $acf_description = get_field('description', $post_id);
+                if (is_string($acf_description) && $acf_description !== '') {
+                    $candidates[] = $acf_description;
+                }
+            }
+
+            $meta_description = get_post_meta($post_id, 'description', true);
+            if (is_string($meta_description) && $meta_description !== '') {
+                $candidates[] = $meta_description;
+            }
+        }
+
+        $excerpt = (string) get_post_field('post_excerpt', $post_id);
+        if ($excerpt !== '') {
+            $candidates[] = $excerpt;
+        }
+
+        $content = (string) get_post_field('post_content', $post_id);
+        if ($content !== '') {
+            $candidates[] = $content;
+        }
+    }
+
+    foreach ($candidates as $candidate) {
+        $clean = hr_sa_trim_text(strip_shortcodes((string) $candidate), 45);
+        if ($clean !== '') {
+            return $clean;
+        }
+    }
+
+    $fallback = (string) get_bloginfo('description', 'display');
+    $clean = hr_sa_trim_text($fallback, 40);
+
+    return $clean !== '' ? $clean : $site_name;
+}
+
+/**
+ * Resolve the country string for the context payload.
+ */
+function hr_sa_resolve_context_country(string $type, int $post_id): string
+{
+    if ($type !== 'trip' || $post_id <= 0) {
+        return '';
+    }
+
+    return hr_sa_resolve_trip_countries($post_id);
+}
+
+/**
+ * Resolve the preferred image URL for the context.
+ */
+function hr_sa_resolve_context_image_url(?int $post_id): ?string
+{
+    $candidates = [];
+
+    if ($post_id) {
+        $meta = get_post_meta($post_id, '_hrih_header_image_url', true);
+        if (is_array($meta) && isset($meta['url'])) {
+            $meta = (string) $meta['url'];
+        }
+        if (is_string($meta) && $meta !== '') {
+            $candidates[] = $meta;
+        }
+    }
+
+    $connector = hr_sa_get_media_help_hero_url();
+    if ($connector) {
+        $candidates[] = $connector;
+    }
+
+    $fallback = (string) hr_sa_get_setting('hr_sa_fallback_image', '');
+    if ($fallback !== '') {
+        $candidates[] = $fallback;
+    }
+
+    $resolved = null;
+    foreach ($candidates as $candidate) {
+        $sanitized = hr_sa_sanitize_context_image_url((string) $candidate);
+        if ($sanitized === null) {
+            continue;
+        }
+
+        $transformed = hr_sa_apply_image_preset_to_url($sanitized);
+        if ($transformed !== '') {
+            $resolved = $transformed;
+            break;
+        }
+    }
+
+    /**
+     * Allow the resolved image URL to be filtered.
+     *
+     * @param string|null $resolved
+     * @param int|null    $post_id
+     */
+    $resolved = apply_filters('hr_sa_context_image_url', $resolved, $post_id);
+
+    return $resolved !== '' ? $resolved : null;
+}
+
+/**
+ * Sanitize hero/fallback image URLs.
+ */
+function hr_sa_sanitize_context_image_url(string $url): ?string
+{
+    $url = trim($url);
+    if ($url === '') {
+        return null;
+    }
+
+    $url = esc_url_raw($url);
+    if ($url === '' || !wp_http_validate_url($url)) {
+        return null;
+    }
+
+    $scheme = strtolower((string) wp_parse_url($url, PHP_URL_SCHEME));
+    if ($scheme && !in_array($scheme, ['http', 'https'], true)) {
+        return null;
+    }
+
+    return set_url_scheme($url, 'https');
+}
+
+/**
+ * Apply the configured CDN preset to an image URL.
+ */
+function hr_sa_apply_image_preset_to_url(string $url): string
+{
+    $preset = trim((string) hr_sa_get_image_preset());
+    if ($preset === '') {
+        return $url;
+    }
+
+    $parts = wp_parse_url($url);
+    if (!is_array($parts) || empty($parts['scheme']) || empty($parts['host'])) {
+        return $url;
+    }
+
+    $query_args = [];
+    if (!empty($parts['query'])) {
+        parse_str((string) $parts['query'], $query_args);
+    }
+
+    foreach (explode(',', $preset) as $segment) {
+        $segment = trim($segment);
+        if ($segment === '' || strpos($segment, '=') === false) {
+            continue;
+        }
+
+        [$key, $value] = array_map('trim', explode('=', $segment, 2));
+        if ($key === '') {
+            continue;
+        }
+
+        $query_args[$key] = $value;
+    }
+
+    $parts['query'] = $query_args ? http_build_query($query_args, '', '&', PHP_QUERY_RFC3986) : '';
+
+    $rebuilt = hr_sa_build_url_from_parts($parts);
+
+    return $rebuilt !== '' ? $rebuilt : $url;
+}
+
+/**
+ * Reconstruct a URL from its parsed components.
+ *
+ * @param array<string, mixed> $parts
+ */
+function hr_sa_build_url_from_parts(array $parts): string
+{
+    $scheme = isset($parts['scheme']) ? $parts['scheme'] . '://' : '';
+    $host   = $parts['host'] ?? '';
+    if ($host === '') {
+        return '';
+    }
+
+    $user = $parts['user'] ?? '';
+    $pass = $parts['pass'] ?? null;
+    $auth = '';
+    if ($user !== '') {
+        $auth = $user;
+        if ($pass !== null) {
+            $auth .= ':' . $pass;
+        }
+        $auth .= '@';
+    }
+
+    $port     = isset($parts['port']) ? ':' . $parts['port'] : '';
+    $path     = $parts['path'] ?? '';
+    $query    = isset($parts['query']) && $parts['query'] !== '' ? '?' . $parts['query'] : '';
+    $fragment = isset($parts['fragment']) ? '#' . $parts['fragment'] : '';
+
+    return $scheme . $auth . $host . $port . $path . $query . $fragment;
 }

--- a/core/feature-flags.php
+++ b/core/feature-flags.php
@@ -19,6 +19,7 @@ function hr_sa_feature_flags_initialize_defaults(): void
     $defaults = [
         'hr_sa_jsonld_enabled'      => '1',
         'hr_sa_og_enabled'          => '0',
+        'hr_sa_twitter_enabled'     => '0',
         'hr_sa_debug_enabled'       => hr_sa_get_settings_defaults()['hr_sa_debug_enabled'],
         'hr_sa_respect_other_seo'   => '1',
     ];
@@ -54,7 +55,30 @@ function hr_sa_is_jsonld_enabled(): bool
 function hr_sa_is_og_enabled(): bool
 {
     $enabled = hr_sa_is_flag_enabled('hr_sa_og_enabled', false);
-    return (bool) apply_filters('hr_sa_og_enabled', $enabled);
+    $enabled = (bool) apply_filters('hr_sa_og_enabled', $enabled);
+
+    /**
+     * Filter whether Open Graph output should be enabled.
+     *
+     * @param bool $enabled
+     */
+    return (bool) apply_filters('hr_sa_enable_og', $enabled);
+}
+
+/**
+ * Whether Twitter Card emission is enabled.
+ */
+function hr_sa_is_twitter_enabled(): bool
+{
+    $enabled = hr_sa_is_flag_enabled('hr_sa_twitter_enabled', false);
+    $enabled = (bool) apply_filters('hr_sa_twitter_enabled', $enabled);
+
+    /**
+     * Filter whether Twitter Card output should be enabled.
+     *
+     * @param bool $enabled
+     */
+    return (bool) apply_filters('hr_sa_enable_twitter', $enabled);
 }
 
 /**

--- a/core/settings.php
+++ b/core/settings.php
@@ -100,6 +100,18 @@ function hr_sa_register_settings(): void
         'default'           => hr_sa_get_settings_defaults()['hr_sa_image_preset'],
     ]);
 
+    register_setting('hr_sa_settings', 'hr_sa_og_enabled', [
+        'type'              => 'boolean',
+        'sanitize_callback' => 'hr_sa_sanitize_checkbox',
+        'default'           => '0',
+    ]);
+
+    register_setting('hr_sa_settings', 'hr_sa_twitter_enabled', [
+        'type'              => 'boolean',
+        'sanitize_callback' => 'hr_sa_sanitize_checkbox',
+        'default'           => '0',
+    ]);
+
     register_setting('hr_sa_settings', 'hr_sa_conflict_mode', [
         'type'              => 'string',
         'sanitize_callback' => 'hr_sa_sanitize_conflict_mode',
@@ -228,7 +240,7 @@ function hr_sa_get_setting(string $option, $default = null)
     $default = $default ?? ($defaults[$option] ?? '');
     $value = get_option($option, $default);
 
-    if (in_array($option, ['hr_sa_tpl_page_brand_suffix', 'hr_sa_debug_enabled'], true)) {
+    if (in_array($option, ['hr_sa_tpl_page_brand_suffix', 'hr_sa_debug_enabled', 'hr_sa_og_enabled', 'hr_sa_twitter_enabled'], true)) {
         return $value === '1' || $value === 1 || $value === true;
     }
 
@@ -249,6 +261,8 @@ function hr_sa_get_all_settings(): array
 
     $settings['hr_sa_tpl_page_brand_suffix'] = hr_sa_get_setting('hr_sa_tpl_page_brand_suffix');
     $settings['hr_sa_debug_enabled'] = hr_sa_get_setting('hr_sa_debug_enabled');
+    $settings['hr_sa_og_enabled'] = hr_sa_is_flag_enabled('hr_sa_og_enabled');
+    $settings['hr_sa_twitter_enabled'] = hr_sa_is_flag_enabled('hr_sa_twitter_enabled');
 
     return $settings;
 }

--- a/hr-seo-assistant.php
+++ b/hr-seo-assistant.php
@@ -3,7 +3,7 @@
  * Plugin Name: HR SEO Assistant
  * Plugin URI:  https://github.com/mandilpradhan/hr-seo-assistant
  * Description: Provides SEO scaffolding, settings, feature flags, and JSON-LD emitters for Himalayan Rides.
- * Version:     0.1.0
+ * Version:     0.2.0
  * Author:      Himalayan Rides
  * License:     GPL-2.0-or-later
  * Text Domain: hr-seo-assistant
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-const HR_SA_VERSION     = '0.1.0';
+const HR_SA_VERSION     = '0.2.0';
 const HR_SA_PLUGIN_FILE = __FILE__;
 const HR_SA_PLUGIN_DIR  = __DIR__ . '/';
 const HR_SA_TEXT_DOMAIN = 'hr-seo-assistant';

--- a/modules/og/loader.php
+++ b/modules/og/loader.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Placeholder OG/Twitter loader for future phases.
+ * Open Graph and Twitter Card emitter.
  *
  * @package HR_SEO_Assistant
  */
@@ -11,15 +11,277 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+/** @var array<string, mixed>|null $hr_sa_last_social_snapshot */
+$GLOBALS['hr_sa_last_social_snapshot'] = null;
+
 /**
- * Stub OG loader hook.
+ * Initialize the OG/Twitter module hooks.
  */
 function hr_sa_bootstrap_og_module(): void
 {
-    if (!hr_sa_is_og_enabled()) {
+    add_action('wp', 'hr_sa_social_meta_maybe_schedule');
+}
+add_action('init', 'hr_sa_bootstrap_og_module');
+
+/**
+ * Schedule social meta output when appropriate.
+ */
+function hr_sa_social_meta_maybe_schedule(): void
+{
+    $GLOBALS['hr_sa_last_social_snapshot'] = null;
+
+    if (!hr_sa_is_og_enabled() && !hr_sa_is_twitter_enabled()) {
         return;
     }
 
-    // TODO: Implement OG/Twitter emission in Phase 1.
+    if (hr_sa_should_respect_other_seo() && hr_sa_other_seo_active()) {
+        return;
+    }
+
+    add_action('wp_head', 'hr_sa_output_social_meta', 15);
 }
-add_action('init', 'hr_sa_bootstrap_og_module');
+
+/**
+ * Print Open Graph and Twitter meta tags in the document head.
+ */
+function hr_sa_output_social_meta(): void
+{
+    $snapshot = hr_sa_get_social_tag_snapshot();
+
+    if ($snapshot['blocked'] || (!$snapshot['og_enabled'] && !$snapshot['twitter_enabled'])) {
+        return;
+    }
+
+    if ($snapshot['og_enabled']) {
+        foreach ($snapshot['og'] as $property => $value) {
+            $content = hr_sa_escape_meta_content($property, $value);
+            if ($content === '') {
+                continue;
+            }
+
+            printf(
+                '<meta property="%1$s" content="%2$s" />' . PHP_EOL,
+                esc_attr($property),
+                $content
+            );
+        }
+    }
+
+    if ($snapshot['twitter_enabled']) {
+        foreach ($snapshot['twitter'] as $name => $value) {
+            $content = hr_sa_escape_meta_content($name, $value);
+            if ($content === '') {
+                continue;
+            }
+
+            printf(
+                '<meta name="%1$s" content="%2$s" />' . PHP_EOL,
+                esc_attr($name),
+                $content
+            );
+        }
+    }
+}
+
+/**
+ * Retrieve (and cache) the computed social tag snapshot for the request.
+ *
+ * @return array{og_enabled: bool, twitter_enabled: bool, blocked: bool, og: array<string, string>, twitter: array<string, string>, fields: array<string, string>}
+ */
+function hr_sa_get_social_tag_snapshot(): array
+{
+    $snapshot = $GLOBALS['hr_sa_last_social_snapshot'] ?? null;
+    if (is_array($snapshot)) {
+        return $snapshot;
+    }
+
+    $snapshot = hr_sa_collect_social_tag_data();
+    $GLOBALS['hr_sa_last_social_snapshot'] = $snapshot;
+
+    return $snapshot;
+}
+
+/**
+ * Build the OG/Twitter snapshot from the shared context.
+ *
+ * @return array{og_enabled: bool, twitter_enabled: bool, blocked: bool, og: array<string, string>, twitter: array<string, string>, fields: array<string, string>}
+ */
+function hr_sa_collect_social_tag_data(): array
+{
+    $context = hr_sa_get_context();
+
+    $blocked         = hr_sa_should_respect_other_seo() && hr_sa_other_seo_active();
+    $og_enabled      = !$blocked && hr_sa_is_og_enabled();
+    $twitter_enabled = !$blocked && hr_sa_is_twitter_enabled();
+
+    $og_tags      = $og_enabled ? hr_sa_prepare_og_tags($context) : [];
+    $twitter_tags = $twitter_enabled ? hr_sa_prepare_twitter_tags($context) : [];
+
+    $fields = [
+        'title'          => (string) ($context['title'] ?? ''),
+        'description'    => (string) ($context['description'] ?? ''),
+        'url'            => (string) ($context['url'] ?? ''),
+        'image'          => (string) ($context['image'] ?? ($context['hero_url'] ?? '')),
+        'site_name'      => (string) ($context['site_name'] ?? ''),
+        'locale'         => (string) ($context['locale'] ?? ''),
+        'twitter_handle' => (string) ($context['twitter_handle'] ?? ''),
+    ];
+
+    $snapshot = [
+        'og_enabled'      => $og_enabled,
+        'twitter_enabled' => $twitter_enabled,
+        'blocked'         => $blocked,
+        'og'              => $og_tags,
+        'twitter'         => $twitter_tags,
+        'fields'          => $fields,
+    ];
+
+    /**
+     * Filter the computed social tag snapshot before it is cached.
+     *
+     * @param array<string, mixed> $snapshot
+     * @param array<string, mixed> $context
+     */
+    return apply_filters('hr_sa_social_tag_snapshot', $snapshot, $context);
+}
+
+/**
+ * Prepare Open Graph tag values from the context array.
+ *
+ * @param array<string, mixed> $context
+ *
+ * @return array<string, string>
+ */
+function hr_sa_prepare_og_tags(array $context): array
+{
+    $title       = trim((string) ($context['title'] ?? ''));
+    $description = trim((string) ($context['description'] ?? ''));
+    $url         = trim((string) ($context['url'] ?? ''));
+    $image       = trim((string) ($context['image'] ?? ($context['hero_url'] ?? '')));
+    $site_name   = trim((string) ($context['site_name'] ?? ''));
+    $locale      = trim((string) ($context['locale'] ?? ''));
+    $type        = hr_sa_map_og_type((string) ($context['type'] ?? ''));
+
+    if ($locale === '') {
+        $locale = get_locale();
+    }
+
+    $tags = [
+        'og:title'       => $title,
+        'og:description' => $description,
+        'og:type'        => $type,
+        'og:url'         => $url,
+        'og:image'       => $image,
+        'og:site_name'   => $site_name,
+        'og:locale'      => $locale,
+    ];
+
+    $tags = array_filter($tags, static fn($value): bool => is_string($value) && $value !== '');
+    $ordered_keys = ['og:title', 'og:description', 'og:type', 'og:url', 'og:image', 'og:site_name', 'og:locale'];
+    $ordered = [];
+    foreach ($ordered_keys as $key) {
+        if (isset($tags[$key])) {
+            $ordered[$key] = $tags[$key];
+        }
+    }
+    foreach ($tags as $key => $value) {
+        if (!isset($ordered[$key])) {
+            $ordered[$key] = $value;
+        }
+    }
+
+    /**
+     * Filter the final Open Graph tag set prior to emission.
+     *
+     * @param array<string, string> $ordered
+     * @param array<string, mixed>  $context
+     */
+    return apply_filters('hr_sa_og_tags', $ordered, $context);
+}
+
+/**
+ * Prepare Twitter Card tag values from the context array.
+ *
+ * @param array<string, mixed> $context
+ *
+ * @return array<string, string>
+ */
+function hr_sa_prepare_twitter_tags(array $context): array
+{
+    $title       = trim((string) ($context['title'] ?? ''));
+    $description = trim((string) ($context['description'] ?? ''));
+    $image       = trim((string) ($context['image'] ?? ($context['hero_url'] ?? '')));
+    $handle      = trim((string) ($context['twitter_handle'] ?? ''));
+
+    $tags = [
+        'twitter:card'        => 'summary_large_image',
+        'twitter:title'       => $title,
+        'twitter:description' => $description,
+        'twitter:image'       => $image,
+    ];
+
+    if ($handle !== '') {
+        $tags['twitter:site'] = $handle;
+    }
+
+    $tags = array_filter($tags, static fn($value): bool => is_string($value) && $value !== '');
+    $ordered_keys = ['twitter:card', 'twitter:title', 'twitter:description', 'twitter:image', 'twitter:site'];
+    $ordered = [];
+    foreach ($ordered_keys as $key) {
+        if (isset($tags[$key])) {
+            $ordered[$key] = $tags[$key];
+        }
+    }
+    foreach ($tags as $key => $value) {
+        if (!isset($ordered[$key])) {
+            $ordered[$key] = $value;
+        }
+    }
+
+    /**
+     * Filter the final Twitter Card tag set prior to emission.
+     *
+     * @param array<string, string> $ordered
+     * @param array<string, mixed>  $context
+     */
+    $ordered = apply_filters('hr_sa_twitter_tags', $ordered, $context);
+
+    if (!isset($ordered['twitter:card'])) {
+        $ordered = ['twitter:card' => 'summary_large_image'] + $ordered;
+    }
+
+    return $ordered;
+}
+
+/**
+ * Map internal content types to Open Graph types.
+ */
+function hr_sa_map_og_type(string $content_type): string
+{
+    switch ($content_type) {
+        case 'home':
+            return 'website';
+        case 'trip':
+            return 'product';
+        default:
+            return 'article';
+    }
+}
+
+/**
+ * Escape meta content values according to their expected type.
+ */
+function hr_sa_escape_meta_content(string $key, string $value): string
+{
+    $value = trim($value);
+    if ($value === '') {
+        return '';
+    }
+
+    $url_keys = ['og:url', 'og:image', 'twitter:image'];
+    if (in_array($key, $url_keys, true)) {
+        return esc_url($value);
+    }
+
+    return esc_attr($value);
+}


### PR DESCRIPTION
## Summary
- generate Open Graph and Twitter Card markup with conflict checks, filters, and reusable snapshots
- enrich the shared SEO context with template-based titles, descriptions, and hero/fallback image resolution
- expose social metadata toggles in settings, surface resolved values on the debug page, and polish admin styling

## Testing
- php -l hr-seo-assistant.php
- php -l core/feature-flags.php
- php -l core/settings.php
- php -l core/context.php
- php -l modules/og/loader.php
- php -l admin/pages/settings.php
- php -l admin/pages/modules.php
- php -l admin/pages/overview.php
- php -l admin/pages/debug.php

------
https://chatgpt.com/codex/tasks/task_e_68d397a7ab9c8327b7f36c8d6edfa807