### PR TITLE
Fix admin asset loading for HR SEO Assistant screens

### DIFF
--- a/admin/menu.php
+++ b/admin/menu.php
@@ -84,23 +84,13 @@ function hr_sa_register_admin_menu(): void
  */
 function hr_sa_enqueue_admin_assets(string $hook_suffix): void
 {
-    $screen = get_current_screen();
-    if (!$screen) {
+    if (strpos($hook_suffix, 'hr-sa-') === false) {
         return;
     }
 
-    $allowed = [
-        'toplevel_page_hr-sa-overview',
-        'hr-sa-overview_page_hr-sa-settings',
-        'hr-sa-overview_page_hr-sa-modules',
-        'hr-sa-overview_page_hr-sa-debug',
-    ];
+    $is_settings_screen = strpos($hook_suffix, 'hr-sa-settings') !== false;
 
-    if (!in_array($screen->id, $allowed, true)) {
-        return;
-    }
-
-    if ($screen->id === 'hr-sa-overview_page_hr-sa-settings') {
+    if ($is_settings_screen) {
         wp_enqueue_media();
     }
 
@@ -111,10 +101,15 @@ function hr_sa_enqueue_admin_assets(string $hook_suffix): void
         HR_SA_VERSION
     );
 
+    $script_dependencies = ['wp-i18n'];
+    if ($is_settings_screen) {
+        $script_dependencies[] = 'media-editor';
+    }
+
     wp_enqueue_script(
         'hr-sa-admin',
         HR_SA_PLUGIN_URL . 'assets/admin.js',
-        ['wp-i18n', 'media-editor'],
+        $script_dependencies,
         HR_SA_VERSION,
         true
     );


### PR DESCRIPTION
## Summary
- ensure admin assets load on all HR SEO Assistant screens by using the hook suffix instead of `get_current_screen()`
- only enqueue media dependencies on the settings page so the media picker works reliably

## Testing
- php -l admin/menu.php

------
https://chatgpt.com/codex/tasks/task_e_68d3ad1008408327890a184565ae18fc