### PR TITLE
Improve debug clipboard fallback

### DIFF
--- a/assets/admin.js
+++ b/assets/admin.js
@@ -108,18 +108,29 @@
         }
     };
 
-    const copyWithClipboard = (text, onSuccess, onFailure) => {
+    const isSecureClipboardSupported = () => {
         const clipboard = navigator.clipboard;
-        const clipboardSupported = Boolean(clipboard && typeof clipboard.writeText === 'function');
+        const hasClipboardApi = Boolean(clipboard && typeof clipboard.writeText === 'function');
+        if (!hasClipboardApi) {
+            return false;
+        }
 
-        if (!clipboardSupported) {
+        if (typeof window.isSecureContext === 'boolean') {
+            return window.isSecureContext;
+        }
+
+        return window.location && window.location.protocol === 'https:';
+    };
+
+    const copyWithClipboard = (text, onSuccess, onFailure) => {
+        if (!isSecureClipboardSupported()) {
             fallbackCopy(text, onSuccess, onFailure);
             return;
         }
 
         let writeResult;
         try {
-            writeResult = clipboard.writeText(text);
+            writeResult = navigator.clipboard.writeText(text);
         } catch (error) {
             fallbackCopy(text, onSuccess, onFailure);
             return;


### PR DESCRIPTION
## Summary
- ensure the debug page copy button only uses the modern clipboard API when the browser is in a secure context
- fall back to the legacy execCommand path immediately when the clipboard API is unavailable or throws

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d3c09b1ee48327b516bc15082c470d