### PR TITLE
feat: wire openai generation flows

### DIFF
--- a/admin/ajax/ai.php
+++ b/admin/ajax/ai.php
@@ -31,17 +31,36 @@ function hr_sa_ajax_ai_test_connection(): void
     }
 
     $settings = hr_sa_ai_get_settings(true);
-    $result = hr_sa_ai_generate('test_connection', [], $settings);
+
+    if (empty($settings['hr_sa_ai_enabled'])) {
+        wp_send_json_error(['message' => __('AI assistance is currently disabled.', HR_SA_TEXT_DOMAIN)], 200);
+    }
+
+    $api_key = isset($settings['hr_sa_ai_api_key']) ? trim((string) $settings['hr_sa_ai_api_key']) : '';
+    if ($api_key === '') {
+        wp_send_json_error(['message' => __('Add an API key before testing the connection.', HR_SA_TEXT_DOMAIN)], 200);
+    }
+
+    $settings['hr_sa_ai_max_tokens'] = 8;
+
+    $context = [
+        'post_id'       => 0,
+        'post_type'     => 'test',
+        'title'         => 'Connectivity check',
+        'excerpt'       => '',
+        'content'       => '',
+        'canonical_url' => '',
+        'site_name'     => '',
+    ];
+
+    $result = hr_sa_ai_generate('title', $context, $settings);
+
     if (is_wp_error($result)) {
         $message = $result->get_error_message();
         wp_send_json_error(['message' => $message], 200);
     }
 
-    $success_message = (string) $result !== ''
-        ? (string) $result
-        : __('Connection successful.', HR_SA_TEXT_DOMAIN);
-
-    wp_send_json_success(['message' => $success_message]);
+    wp_send_json_success(['message' => __('OpenAI reachable', HR_SA_TEXT_DOMAIN)]);
 }
 
 /**

--- a/admin/pages/debug.php
+++ b/admin/pages/debug.php
@@ -201,10 +201,12 @@ function hr_sa_render_debug_page(): void
             <h3><?php esc_html_e('Last AI Request', HR_SA_TEXT_DOMAIN); ?></h3>
             <?php if ($ai_summary) : ?>
                 <?php
-                $summary_type    = isset($ai_summary['type']) ? ucwords(str_replace('_', ' ', (string) $ai_summary['type'])) : '';
-                $summary_status  = isset($ai_summary['status']) ? ucwords((string) $ai_summary['status']) : '';
-                $summary_message = isset($ai_summary['message']) ? (string) $ai_summary['message'] : '';
-                $summary_time    = !empty($ai_summary['timestamp']) ? date_i18n(get_option('date_format') . ' ' . get_option('time_format'), (int) $ai_summary['timestamp']) : '';
+                $summary_type     = isset($ai_summary['type']) ? ucwords(str_replace('_', ' ', (string) $ai_summary['type'])) : '';
+                $summary_status   = isset($ai_summary['status']) ? ucwords((string) $ai_summary['status']) : '';
+                $summary_message  = isset($ai_summary['message']) ? (string) $ai_summary['message'] : '';
+                $summary_time     = !empty($ai_summary['timestamp']) ? date_i18n(get_option('date_format') . ' ' . get_option('time_format'), (int) $ai_summary['timestamp']) : '';
+                $summary_model    = isset($ai_summary['model']) ? (string) $ai_summary['model'] : '';
+                $status_slug      = isset($ai_summary['status']) ? strtolower((string) $ai_summary['status']) : '';
                 ?>
                 <table class="widefat striped">
                     <tbody>
@@ -217,13 +219,19 @@ function hr_sa_render_debug_page(): void
                             <td><?php echo $summary_status !== '' ? esc_html($summary_status) : esc_html__('N/A', HR_SA_TEXT_DOMAIN); ?></td>
                         </tr>
                         <tr>
-                            <th scope="row"><?php esc_html_e('Message', HR_SA_TEXT_DOMAIN); ?></th>
-                            <td><?php echo $summary_message !== '' ? esc_html($summary_message) : esc_html__('N/A', HR_SA_TEXT_DOMAIN); ?></td>
+                            <th scope="row"><?php esc_html_e('Model', HR_SA_TEXT_DOMAIN); ?></th>
+                            <td><?php echo $summary_model !== '' ? esc_html($summary_model) : esc_html__('N/A', HR_SA_TEXT_DOMAIN); ?></td>
                         </tr>
                         <tr>
                             <th scope="row"><?php esc_html_e('Timestamp', HR_SA_TEXT_DOMAIN); ?></th>
                             <td><?php echo $summary_time !== '' ? esc_html($summary_time) : esc_html__('N/A', HR_SA_TEXT_DOMAIN); ?></td>
                         </tr>
+                        <?php if ($status_slug === 'error' && $summary_message !== '') : ?>
+                            <tr>
+                                <th scope="row"><?php esc_html_e('Message', HR_SA_TEXT_DOMAIN); ?></th>
+                                <td><?php echo esc_html($summary_message); ?></td>
+                            </tr>
+                        <?php endif; ?>
                     </tbody>
                 </table>
             <?php else : ?>

--- a/assets/meta-box-ai.js
+++ b/assets/meta-box-ai.js
@@ -36,10 +36,24 @@
 
         const newValue = typeof value === 'string' ? value : '';
         if (field.value === newValue) {
+            if (typeof field.classList !== 'undefined') {
+                if (newValue) {
+                    field.classList.add('hr-sa-ai-filled');
+                } else {
+                    field.classList.remove('hr-sa-ai-filled');
+                }
+            }
             return;
         }
 
         field.value = newValue;
+        if (typeof field.classList !== 'undefined') {
+            if (newValue) {
+                field.classList.add('hr-sa-ai-filled');
+            } else {
+                field.classList.remove('hr-sa-ai-filled');
+            }
+        }
         try {
             field.dispatchEvent(new Event('change', { bubbles: true }));
         } catch (error) {

--- a/core/ai.php
+++ b/core/ai.php
@@ -67,44 +67,106 @@ function hr_sa_ai_get_description_limit(): int
 }
 
 /**
- * Normalize text content by stripping tags, collapsing whitespace, and optionally truncating.
+ * Retrieve the minimum number of keywords required from AI output.
  */
-function hr_sa_ai_normalize_text(?string $text, int $limit = 0): string
+function hr_sa_ai_get_keywords_min(): int
 {
-    $text = is_string($text) ? $text : '';
+    $min = (int) apply_filters('hr_sa_ai_keywords_min', 5);
+
+    return $min > 0 ? $min : 5;
+}
+
+/**
+ * Retrieve the maximum number of keywords allowed from AI output.
+ */
+function hr_sa_ai_get_keywords_max(): int
+{
+    $max = (int) apply_filters('hr_sa_ai_keywords_max', 8);
+    $min = hr_sa_ai_get_keywords_min();
+
+    if ($max < $min) {
+        $max = $min;
+    }
+
+    return $max > 0 ? $max : $min;
+}
+
+/**
+ * Sanitize a text snippet into plain UTF-8, removing markup and normalising whitespace.
+ */
+function hr_sa_ai_sanitize_plain(string $text): string
+{
+    $text = wp_check_invalid_utf8($text, true);
     $text = wp_strip_all_tags($text, true);
+    $text = html_entity_decode($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+    $replacements = [
+        "\xE2\x80\x98" => "'",
+        "\xE2\x80\x99" => "'",
+        "\xE2\x80\x9C" => '"',
+        "\xE2\x80\x9D" => '"',
+        "\xE2\x80\x93" => '-',
+        "\xE2\x80\x94" => '-',
+        "\xE2\x80\xA6" => '...'
+    ];
+
+    $text = strtr($text, $replacements);
+    $text = (string) preg_replace('/[`´‵‶‷]+/u', "'", $text);
+    $text = (string) preg_replace('/"+/u', '"', $text);
     $text = (string) preg_replace('/\s+/u', ' ', $text);
     $text = trim($text);
-
-    if ($limit > 0 && $text !== '') {
-        $text = hr_sa_ai_truncate($text, $limit);
-    }
 
     return $text;
 }
 
 /**
- * Trim text to the supplied character limit while preserving multibyte characters.
+ * Clamp text to a maximum length whilst preferring to cut on word boundaries.
  */
-function hr_sa_ai_truncate(string $value, int $limit): string
+function hr_sa_ai_clamp_length(string $text, int $limit): string
 {
+    $text = trim($text);
     if ($limit <= 0) {
-        return $value;
+        return $text;
     }
 
-    if (function_exists('mb_strlen') && function_exists('mb_substr')) {
-        if (mb_strlen($value) > $limit) {
-            return rtrim(mb_substr($value, 0, $limit));
-        }
-
-        return $value;
+    $length = function_exists('mb_strlen') ? mb_strlen($text) : strlen($text);
+    if ($length <= $limit) {
+        return $text;
     }
 
-    if (strlen($value) > $limit) {
-        return rtrim(substr($value, 0, $limit));
+    $slice = function_exists('mb_substr') ? mb_substr($text, 0, $limit) : substr($text, 0, $limit);
+    $last_space = false;
+    if (function_exists('mb_strrpos')) {
+        $last_space = mb_strrpos($slice, ' ');
+    } else {
+        $last_space = strrpos($slice, ' ');
     }
 
-    return $value;
+    if ($last_space !== false && $last_space > 0) {
+        $slice = function_exists('mb_substr') ? mb_substr($slice, 0, $last_space) : substr($slice, 0, $last_space);
+    }
+
+    $slice = trim($slice);
+    if ($slice === '') {
+        $slice = function_exists('mb_substr') ? mb_substr($text, 0, $limit) : substr($text, 0, $limit);
+    }
+
+    return trim($slice);
+}
+
+/**
+ * Prepare a snippet by sanitising and optionally clamping to a limit.
+ */
+function hr_sa_ai_prepare_snippet($text, int $limit = 0): string
+{
+    $snippet = is_string($text) ? $text : '';
+    $snippet = hr_sa_ai_sanitize_plain($snippet);
+
+    if ($limit > 0) {
+        $snippet = hr_sa_ai_clamp_length($snippet, $limit);
+    }
+
+    return $snippet;
 }
 
 /**
@@ -112,20 +174,19 @@ function hr_sa_ai_truncate(string $value, int $limit): string
  */
 function hr_sa_ai_sanitize_meta_value($value, string $field): string
 {
-    $value = is_string($value) ? $value : '';
-    $value = hr_sa_ai_normalize_text($value);
+    $value = hr_sa_ai_prepare_snippet(is_string($value) ? $value : '');
 
     switch ($field) {
         case 'title':
-            $value = hr_sa_ai_truncate($value, hr_sa_ai_get_title_limit());
+            $value = hr_sa_ai_clamp_length($value, hr_sa_ai_get_title_limit());
             break;
         case 'description':
-            $value = hr_sa_ai_truncate($value, hr_sa_ai_get_description_limit());
+            $value = hr_sa_ai_clamp_length($value, hr_sa_ai_get_description_limit());
             break;
         case 'keywords':
             $value = str_replace(';', ',', $value);
             $value = (string) preg_replace('/\s*,\s*/', ', ', $value);
-            $value = hr_sa_ai_truncate($value, 512);
+            $value = hr_sa_ai_clamp_length($value, 512);
             break;
     }
 
@@ -168,113 +229,35 @@ function hr_sa_ai_prepare_post_context(int $post_id): array
         return [];
     }
 
-    $title   = hr_sa_ai_normalize_text(get_the_title($post_id));
-    $excerpt = (string) get_post_field('post_excerpt', $post_id);
+    $title       = hr_sa_ai_prepare_snippet(get_the_title($post_id), 180);
+    $excerpt_raw = (string) get_post_field('post_excerpt', $post_id);
 
-    if ($excerpt === '') {
-        $raw_excerpt = wp_trim_words(strip_shortcodes((string) get_post_field('post_content', $post_id)), 55, '');
-        $excerpt     = hr_sa_ai_normalize_text($raw_excerpt, 320);
-    } else {
-        $excerpt = hr_sa_ai_normalize_text($excerpt, 320);
+    if ($excerpt_raw === '') {
+        $excerpt_raw = wp_trim_words(strip_shortcodes((string) get_post_field('post_content', $post_id)), 55, '');
     }
 
-    $content_raw = (string) get_post_field('post_content', $post_id);
-    $content     = hr_sa_ai_normalize_text(strip_shortcodes($content_raw), 1200);
-    $permalink   = get_permalink($post_id);
+    $excerpt = hr_sa_ai_prepare_snippet($excerpt_raw, 320);
+
+    $content_raw = strip_shortcodes((string) get_post_field('post_content', $post_id));
+    $content     = hr_sa_ai_prepare_snippet($content_raw, 1200);
+
+    $permalink = get_permalink($post_id);
+    $site_name = hr_sa_ai_prepare_snippet((string) hr_sa_get_setting('hr_sa_site_name', get_bloginfo('name')), 120);
 
     $context = [
-        'post_id'   => $post_id,
-        'post_type' => $post->post_type,
-        'title'     => $title,
-        'excerpt'   => $excerpt,
-        'content'   => $content,
-        'permalink' => $permalink ? esc_url_raw($permalink) : '',
+        'post_id'       => $post_id,
+        'post_type'     => hr_sa_ai_prepare_snippet($post->post_type, 60),
+        'title'         => $title,
+        'excerpt'       => $excerpt,
+        'content'       => $content,
+        'canonical_url' => $permalink ? esc_url_raw($permalink) : '',
+        'permalink'     => $permalink ? esc_url_raw($permalink) : '',
+        'site_name'     => $site_name,
+        'brand_name'    => $site_name,
     ];
 
     if ($post->post_type === 'trip') {
-        $trip_details = [
-            'destinations' => '',
-            'duration'     => '',
-            'price_range'  => '',
-        ];
-
-        if (function_exists('hr_sa_resolve_trip_countries')) {
-            $trip_details['destinations'] = hr_sa_ai_normalize_text(hr_sa_resolve_trip_countries($post_id));
-        }
-
-        $duration = '';
-        if (function_exists('hr_trip_duration_days')) {
-            $days = (int) hr_trip_duration_days($post_id);
-            if ($days > 0) {
-                /* translators: %d: number of days. */
-                $duration = sprintf(_n('%d day', '%d days', $days, HR_SA_TEXT_DOMAIN), $days);
-            }
-        }
-
-        if ($duration === '') {
-            $duration_meta = get_post_meta($post_id, 'duration', true);
-            if (is_string($duration_meta) && $duration_meta !== '') {
-                $duration = hr_sa_ai_normalize_text($duration_meta, 120);
-            }
-        }
-
-        if ($duration === '') {
-            $duration_meta = get_post_meta($post_id, 'trip_duration', true);
-            if (is_string($duration_meta) && $duration_meta !== '') {
-                $duration = hr_sa_ai_normalize_text($duration_meta, 120);
-            }
-        }
-
-        $product_nodes = function_exists('hr_sa_trip_build_product_nodes')
-            ? hr_sa_trip_build_product_nodes($post_id)
-            : [];
-        $product = is_array($product_nodes) ? ($product_nodes[0] ?? []) : [];
-
-        if ($duration === '' && isset($product['additionalProperty']) && is_array($product['additionalProperty'])) {
-            foreach ($product['additionalProperty'] as $property) {
-                if (!is_array($property)) {
-                    continue;
-                }
-                $name  = isset($property['name']) ? strtolower((string) $property['name']) : '';
-                $value = isset($property['value']) ? (string) $property['value'] : '';
-                if ($name === 'duration' && $value !== '') {
-                    $duration = hr_sa_ai_normalize_text($value, 120);
-                    break;
-                }
-            }
-        }
-
-        $price_range = '';
-        if (isset($product['offers']) && is_array($product['offers'])) {
-            $offers   = $product['offers'];
-            $currency = isset($offers['priceCurrency']) ? hr_sa_ai_normalize_text((string) $offers['priceCurrency'], 8) : '';
-            $low      = isset($offers['lowPrice']) && is_numeric($offers['lowPrice']) ? (float) $offers['lowPrice'] : 0.0;
-            $high     = isset($offers['highPrice']) && is_numeric($offers['highPrice']) ? (float) $offers['highPrice'] : 0.0;
-
-            if ($low > 0 && $high > 0) {
-                $formatted_low  = number_format_i18n($low);
-                $formatted_high = number_format_i18n($high);
-                if ($high > $low) {
-                    $price_range = trim(sprintf('%s %s – %s', $currency, $formatted_low, $formatted_high));
-                } else {
-                    $price_range = trim(sprintf('%s %s', $currency, $formatted_high));
-                }
-            } elseif ($low > 0) {
-                $price_range = trim(sprintf('%s %s', $currency, number_format_i18n($low)));
-            }
-        }
-
-        if ($price_range === '') {
-            $price_meta = get_post_meta($post_id, 'price', true);
-            if (is_string($price_meta) && $price_meta !== '') {
-                $price_range = hr_sa_ai_normalize_text($price_meta, 120);
-            }
-        }
-
-        $trip_details['duration']    = $duration;
-        $trip_details['price_range'] = $price_range;
-
-        $context['trip'] = $trip_details;
+        $context['trip'] = hr_sa_ai_prepare_trip_context($post_id);
     }
 
     /**
@@ -287,127 +270,218 @@ function hr_sa_ai_prepare_post_context(int $post_id): array
 }
 
 /**
- * Build the contextual lines included in AI prompts.
+ * Prepare trip-specific context values for prompts.
  *
- * @param array<string, mixed> $context
- *
- * @return array<int, string>
+ * @return array<string, string>
  */
-function hr_sa_ai_build_context_lines(array $context): array
+function hr_sa_ai_prepare_trip_context(int $post_id): array
 {
-    $lines = [];
+    $trip_details = [
+        'destinations' => '',
+        'duration'     => '',
+        'price_range'  => '',
+        'highlights'   => '',
+        'seasonality'  => '',
+    ];
 
-    $site_name = hr_sa_ai_normalize_text((string) hr_sa_get_setting('hr_sa_site_name', get_bloginfo('name')), 120);
-    if ($site_name !== '') {
-        $lines[] = sprintf('Site name: %s', $site_name);
+    if (function_exists('hr_sa_resolve_trip_countries')) {
+        $trip_details['destinations'] = hr_sa_ai_prepare_snippet(hr_sa_resolve_trip_countries($post_id), 240);
     }
 
-    $locale = hr_sa_ai_normalize_text((string) hr_sa_get_setting('hr_sa_locale', 'en_US'), 32);
-    if ($locale !== '') {
-        $lines[] = sprintf('Locale: %s', $locale);
-    }
-
-    if (!empty($context['post_type'])) {
-        $lines[] = sprintf('Post type: %s', hr_sa_ai_normalize_text((string) $context['post_type'], 60));
-    }
-
-    if (!empty($context['title'])) {
-        $lines[] = sprintf('Original title: %s', hr_sa_ai_normalize_text((string) $context['title'], 180));
-    }
-
-    if (!empty($context['excerpt'])) {
-        $lines[] = sprintf('Summary: %s', hr_sa_ai_normalize_text((string) $context['excerpt'], 320));
-    }
-
-    if (!empty($context['content'])) {
-        $lines[] = sprintf('Content notes: %s', hr_sa_ai_normalize_text((string) $context['content'], 1200));
-    }
-
-    if (!empty($context['trip']) && is_array($context['trip'])) {
-        $trip = $context['trip'];
-
-        if (!empty($trip['destinations'])) {
-            $lines[] = sprintf('Destinations: %s', hr_sa_ai_normalize_text((string) $trip['destinations'], 240));
-        }
-
-        if (!empty($trip['duration'])) {
-            $lines[] = sprintf('Duration: %s', hr_sa_ai_normalize_text((string) $trip['duration'], 120));
-        }
-
-        if (!empty($trip['price_range'])) {
-            $lines[] = sprintf('Price range: %s', hr_sa_ai_normalize_text((string) $trip['price_range'], 120));
+    $duration = '';
+    if (function_exists('hr_trip_duration_days')) {
+        $days = (int) hr_trip_duration_days($post_id);
+        if ($days > 0) {
+            /* translators: %d: number of days. */
+            $duration = sprintf(_n('%d day', '%d days', $days, HR_SA_TEXT_DOMAIN), $days);
         }
     }
 
-    return array_values(array_filter(array_map('trim', $lines)));
+    if ($duration === '') {
+        $duration_meta = get_post_meta($post_id, 'duration', true);
+        if (is_string($duration_meta) && $duration_meta !== '') {
+            $duration = hr_sa_ai_prepare_snippet($duration_meta, 120);
+        }
+    }
+
+    if ($duration === '') {
+        $duration_meta = get_post_meta($post_id, 'trip_duration', true);
+        if (is_string($duration_meta) && $duration_meta !== '') {
+            $duration = hr_sa_ai_prepare_snippet($duration_meta, 120);
+        }
+    }
+
+    if ($duration === '') {
+        $duration_meta = get_post_meta($post_id, 'duration_days', true);
+        if (is_string($duration_meta) && $duration_meta !== '') {
+            $duration = hr_sa_ai_prepare_snippet($duration_meta, 120);
+        }
+    }
+
+    $trip_details['duration'] = $duration !== '' ? $duration : '';
+
+    $product_nodes = function_exists('hr_sa_trip_build_product_nodes')
+        ? hr_sa_trip_build_product_nodes($post_id)
+        : [];
+    $product = is_array($product_nodes) ? ($product_nodes[0] ?? []) : [];
+
+    if ($duration === '' && isset($product['additionalProperty']) && is_array($product['additionalProperty'])) {
+        foreach ($product['additionalProperty'] as $property) {
+            if (!is_array($property)) {
+                continue;
+            }
+
+            $name  = isset($property['name']) ? strtolower((string) $property['name']) : '';
+            $value = isset($property['value']) ? (string) $property['value'] : '';
+
+            if ($name === 'duration' && $value !== '') {
+                $duration = hr_sa_ai_prepare_snippet($value, 120);
+                break;
+            }
+        }
+    }
+
+    $price_range = '';
+    if (isset($product['offers']) && is_array($product['offers'])) {
+        $offers   = $product['offers'];
+        $currency = isset($offers['priceCurrency']) ? hr_sa_ai_prepare_snippet((string) $offers['priceCurrency'], 8) : '';
+        $low      = isset($offers['lowPrice']) && is_numeric($offers['lowPrice']) ? (float) $offers['lowPrice'] : 0.0;
+        $high     = isset($offers['highPrice']) && is_numeric($offers['highPrice']) ? (float) $offers['highPrice'] : 0.0;
+
+        if ($low > 0 && $high > 0) {
+            $formatted_low  = number_format_i18n($low);
+            $formatted_high = number_format_i18n($high);
+            if ($high > $low) {
+                $price_range = trim(sprintf('%s %s – %s', $currency, $formatted_low, $formatted_high));
+            } else {
+                $price_range = trim(sprintf('%s %s', $currency, $formatted_high));
+            }
+        } elseif ($low > 0) {
+            $price_range = trim(sprintf('%s %s', $currency, number_format_i18n($low)));
+        }
+    }
+
+    if ($price_range === '') {
+        $price_meta = get_post_meta($post_id, 'price', true);
+        if (is_string($price_meta) && $price_meta !== '') {
+            $price_range = hr_sa_ai_prepare_snippet($price_meta, 120);
+        }
+    }
+
+    $trip_details['price_range'] = $price_range;
+
+    $trip_details['highlights'] = hr_sa_ai_prepare_trip_highlights($post_id);
+    $trip_details['seasonality'] = hr_sa_ai_prepare_trip_seasonality($post_id);
+
+    return array_filter($trip_details, static function ($value) {
+        return is_string($value) && $value !== '';
+    });
 }
 
 /**
- * Build the chat completion messages for a given generation request.
+ * Resolve highlights for a trip if they exist in meta/ACF fields.
+ */
+function hr_sa_ai_prepare_trip_highlights(int $post_id): string
+{
+    $candidate_keys = ['trip_highlights', 'highlights', 'key_highlights', 'highlights_list'];
+
+    foreach ($candidate_keys as $meta_key) {
+        $value = null;
+        if (function_exists('get_field')) {
+            $value = get_field($meta_key, $post_id);
+        }
+
+        if ($value === null) {
+            $value = get_post_meta($post_id, $meta_key, true);
+        }
+
+        if ($value === null || $value === '') {
+            continue;
+        }
+
+        if (is_array($value)) {
+            $value = array_filter(array_map('wp_strip_all_tags', $value));
+            $value = implode(', ', $value);
+        }
+
+        $value = is_string($value) ? hr_sa_ai_prepare_snippet($value, 240) : '';
+        if ($value !== '') {
+            return $value;
+        }
+    }
+
+    return '';
+}
+
+/**
+ * Resolve seasonality/best time details for a trip.
+ */
+function hr_sa_ai_prepare_trip_seasonality(int $post_id): string
+{
+    $candidate_keys = ['seasons', 'seasonality', 'best_time', 'best_time_to_visit', 'trip_season'];
+
+    foreach ($candidate_keys as $meta_key) {
+        $value = null;
+        if (function_exists('get_field')) {
+            $value = get_field($meta_key, $post_id);
+        }
+
+        if ($value === null) {
+            $value = get_post_meta($post_id, $meta_key, true);
+        }
+
+        if ($value === null || $value === '') {
+            continue;
+        }
+
+        if (is_array($value)) {
+            $value = array_filter(array_map('wp_strip_all_tags', $value));
+            $value = implode(', ', $value);
+        }
+
+        $value = is_string($value) ? hr_sa_ai_prepare_snippet($value, 200) : '';
+        if ($value !== '') {
+            return $value;
+        }
+    }
+
+    return '';
+}
+
+/**
+ * Build chat completion messages for a given generation request.
  *
  * @param array<string, mixed> $context
  *
- * @return array<int, array<string, string>>|WP_Error
+ * @return array<int, array<string, string>>
  */
-function hr_sa_ai_build_messages(string $type_key, array $context)
+function hr_sa_ai_build_messages(string $type, array $context): array
 {
-    $type_key = $type_key !== '' ? $type_key : 'generic';
+    $title_limit       = hr_sa_ai_get_title_limit();
+    $description_limit = hr_sa_ai_get_description_limit();
 
-    $system_parts = [
-        'You are an SEO assistant for a WordPress site. Provide concise, high quality metadata.',
-        'Respond with plain text only. Do not include HTML, quotes, code blocks, or Markdown.',
-    ];
+    $system_message = 'You are a senior SEO copy assistant for a Himalayan adventure travel website. Return clean plain text with no quotes, HTML, or Markdown.';
 
-    $locale = hr_sa_ai_normalize_text((string) hr_sa_get_setting('hr_sa_locale', 'en_US'), 32);
-    if ($locale !== '') {
-        $system_parts[] = sprintf('Write in %s.', $locale);
-    }
-
-    $system_message = implode(' ', array_filter($system_parts));
-
-    $context_lines = hr_sa_ai_build_context_lines($context);
-    $context_text  = implode("\n", $context_lines);
-
-    $title_limit = hr_sa_ai_get_title_limit();
-    $desc_limit  = hr_sa_ai_get_description_limit();
-
-    switch ($type_key) {
+    switch ($type) {
         case 'title':
-            $instruction = sprintf(
-                'Generate an SEO title no longer than %d characters. Focus on clarity, destination, and trip highlights.',
+            $policy_message = sprintf(
+                '≤ %d characters, succinct, compelling, include focus topic early, no brand name unless provided.',
                 $title_limit
             );
+            $user_message = hr_sa_ai_prompt_template_title($context, $title_limit);
             break;
         case 'description':
-            $instruction = sprintf(
-                'Generate an engaging SEO meta description no longer than %d characters. Summarize key details and include a call to action.',
-                $desc_limit
+            $policy_message = sprintf(
+                '≤ %d characters, persuasive, active voice, include unique value, no trailing ellipsis.',
+                $description_limit
             );
+            $user_message = hr_sa_ai_prompt_template_description($context, $description_limit);
             break;
         case 'keywords':
-            $instruction = 'Generate 6-10 SEO keywords separated by commas. Prioritize destinations, activities, and travel themes. Do not number the list.';
-            break;
-        case 'test_connection':
-            $instruction = 'Respond with the single word PONG to confirm the service is reachable.';
-            $context_text = '';
-            break;
         default:
-            if ($type_key === '') {
-                $type_key = 'generic';
-            }
-            $instruction = 'Generate a concise SEO suggestion based on the provided context.';
+            $policy_message = '5–8 comma-separated keywords/phrases; no hashtags, no duplicates, no stop words.';
+            $user_message   = hr_sa_ai_prompt_template_keywords($context);
             break;
-    }
-
-    if ($type_key !== 'test_connection' && $context_text === '') {
-        $message = __('We could not prepare enough context for AI generation.', HR_SA_TEXT_DOMAIN);
-
-        return new WP_Error('hr_sa_ai_missing_context', $message);
-    }
-
-    $user_message = $instruction;
-    if ($context_text !== '') {
-        $user_message .= "\n\nContext:\n" . $context_text;
     }
 
     $messages = [
@@ -416,19 +490,187 @@ function hr_sa_ai_build_messages(string $type_key, array $context)
             'content' => $system_message,
         ],
         [
+            'role'    => 'system',
+            'content' => $policy_message,
+        ],
+        [
             'role'    => 'user',
             'content' => $user_message,
         ],
     ];
 
-    /**
-     * Filter the chat completion messages before the request is dispatched.
-     *
-     * @param array<int, array<string, string>> $messages
-     * @param string                            $type_key
-     * @param array<string, mixed>              $context
-     */
-    return apply_filters('hr_sa_ai_request_messages', $messages, $type_key, $context);
+    $filter_name = 'hr_sa_ai_prompt_' . $type;
+    $messages    = apply_filters($filter_name, $messages, $context);
+
+    return array_values(array_filter(array_map(static function ($message) {
+        if (!is_array($message) || empty($message['role']) || empty($message['content'])) {
+            return null;
+        }
+
+        return [
+            'role'    => (string) $message['role'],
+            'content' => (string) $message['content'],
+        ];
+    }, $messages)));
+}
+
+/**
+ * Prompt template for title generation.
+ */
+function hr_sa_ai_prompt_template_title(array $context, int $title_limit): string
+{
+    $post_type  = hr_sa_ai_prepare_snippet((string) ($context['post_type'] ?? 'post'), 60);
+    $post_title = hr_sa_ai_prepare_snippet((string) ($context['title'] ?? ''), 200);
+    $excerpt    = hr_sa_ai_prepare_snippet((string) ($context['excerpt'] ?? ''), 320);
+    $content    = hr_sa_ai_prepare_snippet((string) ($context['content'] ?? ''), 400);
+    $canonical  = hr_sa_ai_prepare_snippet((string) ($context['canonical_url'] ?? ''), 200);
+    $site_name  = hr_sa_ai_prepare_snippet((string) ($context['site_name'] ?? ''), 120);
+
+    $key_points = $content !== '' ? $content : $excerpt;
+
+    $lines = [
+        sprintf('Task: Write an SEO title for a %s.', $post_type !== '' ? $post_type : 'post'),
+        sprintf('Constraints: <= %d characters; compelling; lead with the main topic; no quotes or emojis; neutral punctuation; no brand unless provided.', $title_limit),
+        'Context:',
+        '- Title: ' . ($post_title !== '' ? $post_title : 'N/A'),
+    ];
+
+    if ($excerpt !== '') {
+        $lines[] = '- Excerpt: ' . $excerpt;
+    }
+
+    if ($key_points !== '') {
+        $lines[] = '- Key points: ' . $key_points;
+    }
+
+    if ($content !== '' && $content !== $key_points) {
+        $lines[] = '- Content summary: ' . $content;
+    }
+
+    $trip_context = hr_sa_ai_format_trip_context($context['trip'] ?? []);
+    if ($trip_context !== '') {
+        $lines[] = '- Trip data (if applicable): ' . $trip_context;
+    }
+
+    if ($site_name !== '') {
+        $lines[] = '- Site/Brand: ' . $site_name;
+    }
+
+    if ($canonical !== '') {
+        $lines[] = '- Canonical URL: ' . $canonical;
+    }
+
+    $lines[] = 'Output: plain text, single line.';
+
+    return implode("\n", array_filter($lines));
+}
+
+/**
+ * Prompt template for description generation.
+ */
+function hr_sa_ai_prompt_template_description(array $context, int $description_limit): string
+{
+    $post_type  = hr_sa_ai_prepare_snippet((string) ($context['post_type'] ?? 'post'), 60);
+    $post_title = hr_sa_ai_prepare_snippet((string) ($context['title'] ?? ''), 200);
+    $excerpt    = hr_sa_ai_prepare_snippet((string) ($context['excerpt'] ?? ''), 320);
+    $content    = hr_sa_ai_prepare_snippet((string) ($context['content'] ?? ''), 600);
+    $canonical  = hr_sa_ai_prepare_snippet((string) ($context['canonical_url'] ?? ''), 200);
+    $site_name  = hr_sa_ai_prepare_snippet((string) ($context['site_name'] ?? ''), 120);
+
+    $lines = [
+        sprintf('Task: Write an SEO meta description for a %s.', $post_type !== '' ? $post_type : 'post'),
+        sprintf('Constraints: <= %d characters; persuasive, active voice; highlight unique value; avoid generic fluff; no quotes or emojis.', $description_limit),
+        'Context:',
+        '- Title: ' . ($post_title !== '' ? $post_title : 'N/A'),
+    ];
+
+    if ($excerpt !== '') {
+        $lines[] = '- Excerpt: ' . $excerpt;
+    }
+
+    if ($content !== '') {
+        $lines[] = '- Summary: ' . $content;
+    }
+
+    $trip_context = hr_sa_ai_format_trip_context($context['trip'] ?? []);
+    if ($trip_context !== '') {
+        $lines[] = '- Trip data (if applicable): ' . $trip_context;
+    }
+
+    if ($site_name !== '') {
+        $lines[] = '- Site/Brand: ' . $site_name;
+    }
+
+    if ($canonical !== '') {
+        $lines[] = '- Canonical URL: ' . $canonical;
+    }
+
+    $lines[] = 'Output: plain text, single line (or two short sentences).';
+
+    return implode("\n", array_filter($lines));
+}
+
+/**
+ * Prompt template for keyword generation.
+ */
+function hr_sa_ai_prompt_template_keywords(array $context): string
+{
+    $post_type = hr_sa_ai_prepare_snippet((string) ($context['post_type'] ?? 'post'), 60);
+    $title     = hr_sa_ai_prepare_snippet((string) ($context['title'] ?? ''), 200);
+    $excerpt   = hr_sa_ai_prepare_snippet((string) ($context['excerpt'] ?? ''), 320);
+
+    $parts = array_filter([
+        $title,
+        $excerpt,
+        is_array($context['trip'] ?? null) && !empty($context['trip']['destinations']) ? hr_sa_ai_prepare_snippet((string) $context['trip']['destinations'], 200) : '',
+    ]);
+
+    $context_line = implode(' | ', $parts);
+
+    $lines = [
+        sprintf('Task: Provide SEO keywords for a %s.', $post_type !== '' ? $post_type : 'post'),
+        'Constraints: 5-8 concise comma-separated keywords/phrases; no hashtags; no duplication; avoid stop-words.',
+        'Context: ' . ($context_line !== '' ? $context_line : 'No additional context provided'),
+        'Output: plain text, comma-separated.'
+    ];
+
+    return implode("\n", $lines);
+}
+
+/**
+ * Format trip context for inclusion in prompt templates.
+ *
+ * @param array<string, string> $trip
+ */
+function hr_sa_ai_format_trip_context($trip): string
+{
+    if (!is_array($trip) || !$trip) {
+        return '';
+    }
+
+    $parts = [];
+    $labels = [
+        'duration'    => 'duration',
+        'destinations'=> 'destinations',
+        'price_range' => 'price_range',
+        'highlights'  => 'highlights',
+        'seasonality' => 'seasonality',
+    ];
+
+    foreach ($labels as $key => $label) {
+        if (empty($trip[$key])) {
+            continue;
+        }
+
+        $value = hr_sa_ai_prepare_snippet((string) $trip[$key], 200);
+        if ($value === '') {
+            continue;
+        }
+
+        $parts[] = sprintf('%s=%s', $label, $value);
+    }
+
+    return implode(', ', $parts);
 }
 
 /**
@@ -445,245 +687,275 @@ function hr_sa_ai_generate(string $type, array $context, array $settings)
         return new WP_Error('hr_sa_ai_forbidden', __('You do not have permission to generate AI content.', HR_SA_TEXT_DOMAIN));
     }
 
-    $type_key              = sanitize_key($type) ?: 'generic';
-    $ai_settings           = $settings ?: hr_sa_ai_get_settings(true);
-    $display_notice_errors = $type_key !== 'test_connection';
+    $type = sanitize_key($type);
 
-    if (empty($ai_settings['hr_sa_ai_enabled'])) {
+    if (!hr_sa_ai_is_enabled()) {
         $message = __('AI assistance is currently disabled. Enable it in the settings page.', HR_SA_TEXT_DOMAIN);
         hr_sa_ai_store_last_request_summary([
-            'type'           => $type_key,
-            'status'         => 'error',
-            'message'        => $message,
-            'display_notice' => $display_notice_errors,
+            'timestamp'   => time(),
+            'type'        => $type,
+            'status'      => 'error',
+            'message'     => $message,
+            'post_id'     => isset($context['post_id']) ? (int) $context['post_id'] : 0,
+            'model'       => '',
+            'temperature' => null,
+            'max_tokens'  => null,
         ]);
 
         return new WP_Error('hr_sa_ai_disabled', $message);
     }
 
-    if (empty($ai_settings['hr_sa_ai_api_key'])) {
+    $allowed_types = ['title', 'description', 'keywords'];
+    if (!in_array($type, $allowed_types, true)) {
+        return new WP_Error('hr_sa_ai_invalid_type', __('Unsupported AI generation type.', HR_SA_TEXT_DOMAIN));
+    }
+
+    $api_key = isset($settings['hr_sa_ai_api_key']) ? trim((string) $settings['hr_sa_ai_api_key']) : '';
+    if ($api_key === '') {
         $message = __('Add an API key before generating AI content.', HR_SA_TEXT_DOMAIN);
         hr_sa_ai_store_last_request_summary([
-            'type'           => $type_key,
-            'status'         => 'error',
-            'message'        => $message,
-            'display_notice' => $display_notice_errors,
+            'timestamp'   => time(),
+            'type'        => $type,
+            'status'      => 'error',
+            'message'     => $message,
+            'post_id'     => isset($context['post_id']) ? (int) $context['post_id'] : 0,
+            'model'       => '',
+            'temperature' => null,
+            'max_tokens'  => null,
         ]);
 
         return new WP_Error('hr_sa_ai_missing_key', $message);
     }
 
-    $messages = hr_sa_ai_build_messages($type_key, $context);
-    if (is_wp_error($messages)) {
-        $message = $messages->get_error_message();
-        hr_sa_ai_store_last_request_summary([
-            'type'           => $type_key,
-            'status'         => 'error',
-            'message'        => $message,
-            'display_notice' => $display_notice_errors,
-        ]);
+    $model = isset($settings['hr_sa_ai_model']) && $settings['hr_sa_ai_model'] !== ''
+        ? sanitize_text_field((string) $settings['hr_sa_ai_model'])
+        : 'gpt-4o-mini';
 
-        return $messages;
-    }
-
-    $model = isset($ai_settings['hr_sa_ai_model']) && $ai_settings['hr_sa_ai_model'] !== ''
-        ? sanitize_text_field((string) $ai_settings['hr_sa_ai_model'])
-        : (string) hr_sa_get_settings_defaults()['hr_sa_ai_model'];
-
-    $temperature = isset($ai_settings['hr_sa_ai_temperature'])
-        ? (float) $ai_settings['hr_sa_ai_temperature']
-        : (float) hr_sa_get_settings_defaults()['hr_sa_ai_temperature'];
+    $temperature = isset($settings['hr_sa_ai_temperature'])
+        ? (float) $settings['hr_sa_ai_temperature']
+        : 0.7;
     $temperature = max(0.0, min(2.0, $temperature));
-    if ($type_key === 'test_connection') {
-        $temperature = 0.0;
+
+    $max_tokens_setting = isset($settings['hr_sa_ai_max_tokens'])
+        ? (int) $settings['hr_sa_ai_max_tokens']
+        : 512;
+    if ($max_tokens_setting <= 0) {
+        $max_tokens_setting = 512;
     }
 
-    $max_tokens = isset($ai_settings['hr_sa_ai_max_tokens'])
-        ? (int) $ai_settings['hr_sa_ai_max_tokens']
-        : (int) hr_sa_get_settings_defaults()['hr_sa_ai_max_tokens'];
-    $max_tokens = max(16, min(4096, $max_tokens));
-
-    switch ($type_key) {
-        case 'title':
-            $max_tokens = min($max_tokens, 128);
-            break;
-        case 'description':
-            $max_tokens = min($max_tokens, 192);
-            break;
-        case 'keywords':
-            $max_tokens = min($max_tokens, 256);
-            break;
-        case 'test_connection':
-            $max_tokens = min($max_tokens, 32);
-            break;
-        default:
-            $max_tokens = min($max_tokens, 256);
-            break;
+    $messages = hr_sa_ai_build_messages($type, $context);
+    if (!$messages) {
+        return new WP_Error('hr_sa_ai_invalid_prompt', __('We could not prepare enough context for AI generation.', HR_SA_TEXT_DOMAIN));
     }
 
-    $request_body = [
+    $endpoint = apply_filters('hr_sa_ai_http_endpoint', 'https://api.openai.com/v1/chat/completions', $type, $context, $settings);
+
+    $payload = [
         'model'       => $model,
-        'messages'    => $messages,
         'temperature' => $temperature,
-        'max_tokens'  => $max_tokens,
+        'max_tokens'  => $max_tokens_setting,
+        'messages'    => $messages,
     ];
 
-    /**
-     * Filter the request body before it is encoded to JSON.
-     *
-     * @param array<string, mixed> $request_body
-     * @param string               $type_key
-     * @param array<string, mixed> $context
-     * @param array<string, mixed> $settings
-     */
-    $request_body = apply_filters('hr_sa_ai_request_body', $request_body, $type_key, $context, $ai_settings);
-
-    $encoded_body = wp_json_encode($request_body);
-    if ($encoded_body === false) {
-        $message = __('We could not encode the AI request payload.', HR_SA_TEXT_DOMAIN);
-        hr_sa_ai_store_last_request_summary([
-            'type'           => $type_key,
-            'status'         => 'error',
-            'message'        => $message,
-            'display_notice' => $display_notice_errors,
-        ]);
-
-        return new WP_Error('hr_sa_ai_payload_error', $message);
+    $body = wp_json_encode($payload);
+    if (!is_string($body) || $body === '') {
+        return new WP_Error('hr_sa_ai_payload_error', __('Failed to encode AI request.', HR_SA_TEXT_DOMAIN));
     }
 
-    $endpoint = apply_filters('hr_sa_ai_endpoint', 'https://api.openai.com/v1/chat/completions', $type_key, $context, $ai_settings);
-
-    $request_args = [
-        'timeout'    => 30,
-        'headers'    => [
+    $response = wp_remote_post($endpoint, [
+        'headers' => [
+            'Authorization' => 'Bearer ' . $api_key,
             'Content-Type'  => 'application/json',
-            'Authorization' => 'Bearer ' . $ai_settings['hr_sa_ai_api_key'],
         ],
-        'body'       => $encoded_body,
-        'data_format'=> 'body',
-        'user-agent' => 'HR SEO Assistant/' . HR_SA_VERSION,
-    ];
-
-    /**
-     * Filter the HTTP request arguments before dispatching the AI call.
-     *
-     * @param array<string, mixed> $request_args
-     * @param array<string, mixed> $request_body
-     * @param string               $type_key
-     * @param array<string, mixed> $context
-     * @param array<string, mixed> $settings
-     */
-    $request_args = apply_filters('hr_sa_ai_request_args', $request_args, $request_body, $type_key, $context, $ai_settings);
-
-    $response = wp_remote_post($endpoint, $request_args);
-    if (is_wp_error($response)) {
-        $error_message = $response->get_error_message();
-        $message       = $error_message !== ''
-            ? sprintf(__('The AI request failed: %s', HR_SA_TEXT_DOMAIN), $error_message)
-            : __('The AI request failed due to an unknown error.', HR_SA_TEXT_DOMAIN);
-
-        hr_sa_ai_store_last_request_summary([
-            'type'           => $type_key,
-            'status'         => 'error',
-            'message'        => $message,
-            'display_notice' => $display_notice_errors,
-        ]);
-
-        return new WP_Error('hr_sa_ai_http_error', $message, $response);
-    }
-
-    $code = (int) wp_remote_retrieve_response_code($response);
-    $body = wp_remote_retrieve_body($response);
-    $data = json_decode($body, true);
-
-    if ($code < 200 || $code >= 300) {
-        $api_message = '';
-        if (is_array($data) && isset($data['error']['message'])) {
-            $api_message = hr_sa_ai_normalize_text((string) $data['error']['message'], 240);
-        }
-
-        $message = $api_message !== ''
-            ? sprintf(__('The AI service returned an error: %s', HR_SA_TEXT_DOMAIN), $api_message)
-            : sprintf(__('The AI service returned an unexpected HTTP %d response.', HR_SA_TEXT_DOMAIN), $code);
-
-        hr_sa_ai_store_last_request_summary([
-            'type'           => $type_key,
-            'status'         => 'error',
-            'message'        => $message,
-            'display_notice' => $display_notice_errors,
-        ]);
-
-        return new WP_Error('hr_sa_ai_response_error', $message, $response);
-    }
-
-    if (!is_array($data)) {
-        $message = __('The AI service returned an unreadable response.', HR_SA_TEXT_DOMAIN);
-        hr_sa_ai_store_last_request_summary([
-            'type'           => $type_key,
-            'status'         => 'error',
-            'message'        => $message,
-            'display_notice' => $display_notice_errors,
-        ]);
-
-        return new WP_Error('hr_sa_ai_invalid_json', $message);
-    }
-
-    $content = '';
-    if (isset($data['choices']) && is_array($data['choices']) && isset($data['choices'][0])) {
-        $choice = $data['choices'][0];
-        if (is_array($choice) && isset($choice['message']['content'])) {
-            $content = (string) $choice['message']['content'];
-        } elseif (is_array($choice) && isset($choice['text'])) {
-            $content = (string) $choice['text'];
-        }
-    }
-
-    if ($content === '') {
-        $message = __('The AI service returned an empty response.', HR_SA_TEXT_DOMAIN);
-        hr_sa_ai_store_last_request_summary([
-            'type'           => $type_key,
-            'status'         => 'error',
-            'message'        => $message,
-            'display_notice' => $display_notice_errors,
-        ]);
-
-        return new WP_Error('hr_sa_ai_empty_response', $message, $data);
-    }
-
-    $sanitized = hr_sa_ai_sanitize_meta_value($content, $type_key);
-    if ($sanitized === '') {
-        $message = __('The AI response could not be sanitized.', HR_SA_TEXT_DOMAIN);
-        hr_sa_ai_store_last_request_summary([
-            'type'           => $type_key,
-            'status'         => 'error',
-            'message'        => $message,
-            'display_notice' => $display_notice_errors,
-        ]);
-
-        return new WP_Error('hr_sa_ai_sanitization_failed', $message, $data);
-    }
-
-    $summary_messages = [
-        'title'           => __('Generated title suggestion.', HR_SA_TEXT_DOMAIN),
-        'description'     => __('Generated description suggestion.', HR_SA_TEXT_DOMAIN),
-        'keywords'        => __('Generated keyword suggestion.', HR_SA_TEXT_DOMAIN),
-        'test_connection' => __('Connection successful.', HR_SA_TEXT_DOMAIN),
-    ];
-
-    $summary_message = $summary_messages[$type_key] ?? __('AI request completed.', HR_SA_TEXT_DOMAIN);
-
-    hr_sa_ai_store_last_request_summary([
-        'type'           => $type_key,
-        'status'         => 'success',
-        'message'        => $summary_message,
-        'display_notice' => false,
+        'body'    => $body,
+        'timeout' => 20,
     ]);
 
-    if ($type_key === 'test_connection') {
-        return $summary_message;
+    $post_id = isset($context['post_id']) ? (int) $context['post_id'] : 0;
+
+    if (is_wp_error($response)) {
+        $message = $response->get_error_message();
+        $message = $message !== '' ? $message : __('Unable to reach the AI service.', HR_SA_TEXT_DOMAIN);
+        hr_sa_ai_store_last_request_summary([
+            'timestamp'   => time(),
+            'type'        => $type,
+            'status'      => 'error',
+            'message'     => $message,
+            'model'       => $model,
+            'temperature' => $temperature,
+            'max_tokens'  => $max_tokens_setting,
+            'post_id'     => $post_id,
+        ]);
+
+        return new WP_Error('hr_sa_http_error', $message);
     }
 
-    return $sanitized;
+    $status = (int) wp_remote_retrieve_response_code($response);
+    $raw_body = wp_remote_retrieve_body($response);
+
+    $data = json_decode($raw_body, true);
+    if (!is_array($data)) {
+        $message = __('The AI service returned an invalid response.', HR_SA_TEXT_DOMAIN);
+        hr_sa_ai_store_last_request_summary([
+            'timestamp'   => time(),
+            'type'        => $type,
+            'status'      => 'error',
+            'message'     => $message,
+            'model'       => $model,
+            'temperature' => $temperature,
+            'max_tokens'  => $max_tokens_setting,
+            'post_id'     => $post_id,
+        ]);
+
+        return new WP_Error('hr_sa_ai_invalid_response', $message);
+    }
+
+    if ($status < 200 || $status >= 300) {
+        $error_message = '';
+        if (isset($data['error']['message'])) {
+            $error_message = hr_sa_ai_prepare_snippet((string) $data['error']['message'], 200);
+        }
+
+        $message = $error_message !== '' ? $error_message : __('The AI service responded with an error.', HR_SA_TEXT_DOMAIN);
+        hr_sa_ai_store_last_request_summary([
+            'timestamp'   => time(),
+            'type'        => $type,
+            'status'      => 'error',
+            'message'     => $message,
+            'model'       => $model,
+            'temperature' => $temperature,
+            'max_tokens'  => $max_tokens_setting,
+            'post_id'     => $post_id,
+        ]);
+
+        return new WP_Error('hr_sa_http_error', $message);
+    }
+
+    $choice = $data['choices'][0]['message']['content'] ?? '';
+    if (!is_string($choice) || $choice === '') {
+        $message = __('The AI response did not include any content.', HR_SA_TEXT_DOMAIN);
+        hr_sa_ai_store_last_request_summary([
+            'timestamp'   => time(),
+            'type'        => $type,
+            'status'      => 'error',
+            'message'     => $message,
+            'model'       => $model,
+            'temperature' => $temperature,
+            'max_tokens'  => $max_tokens_setting,
+            'post_id'     => $post_id,
+        ]);
+
+        return new WP_Error('hr_sa_ai_empty', $message);
+    }
+
+    $output = hr_sa_ai_prepare_snippet($choice);
+
+    $keyword_count = 0;
+
+    switch ($type) {
+        case 'title':
+            $output = hr_sa_ai_clamp_length($output, hr_sa_ai_get_title_limit());
+            $output = preg_replace('/[\p{Zs}\s]+/u', ' ', $output ?? '');
+            $output = trim((string) $output);
+            $output = (string) preg_replace('/([!?.,])\1+$/u', '$1', $output);
+            break;
+        case 'description':
+            $output = hr_sa_ai_clamp_length($output, hr_sa_ai_get_description_limit());
+            $output = preg_replace('/\s+/u', ' ', $output ?? '');
+            $output = trim((string) $output);
+            break;
+        case 'keywords':
+            $raw_items = array_map('trim', explode(',', $output));
+            $unique_map = [];
+
+            foreach ($raw_items as $raw_item) {
+                $keyword = hr_sa_ai_prepare_snippet($raw_item, 120);
+                if ($keyword === '') {
+                    continue;
+                }
+
+                $lower = function_exists('mb_strtolower')
+                    ? mb_strtolower($keyword, 'UTF-8')
+                    : strtolower($keyword);
+
+                if (isset($unique_map[$lower])) {
+                    continue;
+                }
+
+                $unique_map[$lower] = $keyword;
+            }
+
+            $normalized = array_values($unique_map);
+
+            $keywords_min = hr_sa_ai_get_keywords_min();
+            $keywords_max = hr_sa_ai_get_keywords_max();
+
+            if (count($normalized) < $keywords_min) {
+                $message = __('The AI service did not return enough keywords. Please try again.', HR_SA_TEXT_DOMAIN);
+                hr_sa_ai_store_last_request_summary([
+                    'timestamp'   => time(),
+                    'type'        => $type,
+                    'status'      => 'error',
+                    'message'     => $message,
+                    'model'       => $model,
+                    'temperature' => $temperature,
+                    'max_tokens'  => $max_tokens_setting,
+                    'post_id'     => $post_id,
+                ]);
+
+                return new WP_Error('hr_sa_ai_keywords_insufficient', $message);
+            }
+
+            if (count($normalized) > $keywords_max) {
+                $normalized = array_slice($normalized, 0, $keywords_max);
+            }
+
+            $keyword_count = count($normalized);
+            $output = implode(', ', $normalized);
+            break;
+    }
+
+    if (!is_string($output) || $output === '') {
+        $message = __('The AI response was empty after sanitization. Please try again.', HR_SA_TEXT_DOMAIN);
+        hr_sa_ai_store_last_request_summary([
+            'timestamp'   => time(),
+            'type'        => $type,
+            'status'      => 'error',
+            'message'     => $message,
+            'model'       => $model,
+            'temperature' => $temperature,
+            'max_tokens'  => $max_tokens_setting,
+            'post_id'     => $post_id,
+        ]);
+
+        return new WP_Error('hr_sa_ai_empty', $message);
+    }
+
+    $summary_message = '';
+    switch ($type) {
+        case 'title':
+            $summary_message = sprintf(__('Generated title (%d characters).', HR_SA_TEXT_DOMAIN), function_exists('mb_strlen') ? mb_strlen($output) : strlen($output));
+            break;
+        case 'description':
+            $summary_message = sprintf(__('Generated description (%d characters).', HR_SA_TEXT_DOMAIN), function_exists('mb_strlen') ? mb_strlen($output) : strlen($output));
+            break;
+        case 'keywords':
+            $summary_message = sprintf(__('Generated keywords (%d items).', HR_SA_TEXT_DOMAIN), $keyword_count);
+            break;
+    }
+
+    hr_sa_ai_store_last_request_summary([
+        'timestamp'   => time(),
+        'type'        => $type,
+        'status'      => 'success',
+        'message'     => $summary_message,
+        'model'       => $model,
+        'temperature' => $temperature,
+        'max_tokens'  => $max_tokens_setting,
+        'post_id'     => $post_id,
+    ]);
+
+    return $output;
 }
 
 /**
@@ -722,11 +994,15 @@ function hr_sa_ai_get_last_request_summary(): ?array
 function hr_sa_ai_normalize_request_summary(array $summary): array
 {
     $defaults = [
-        'timestamp'      => time(),
-        'type'           => 'generic',
-        'status'         => '',
-        'message'        => '',
+        'timestamp'   => time(),
+        'type'        => 'generic',
+        'status'      => '',
+        'message'     => '',
         'display_notice' => false,
+        'model'       => '',
+        'temperature' => null,
+        'max_tokens'  => null,
+        'post_id'     => 0,
     ];
 
     $summary = array_merge($defaults, array_intersect_key($summary, $defaults));
@@ -738,8 +1014,12 @@ function hr_sa_ai_normalize_request_summary(array $summary): array
 
     $summary['type'] = $summary['type'] !== '' ? sanitize_key((string) $summary['type']) : 'generic';
     $summary['status'] = $summary['status'] !== '' ? sanitize_key((string) $summary['status']) : '';
-    $summary['message'] = hr_sa_ai_normalize_text((string) $summary['message']);
+    $summary['message'] = hr_sa_ai_prepare_snippet((string) $summary['message'], 240);
     $summary['display_notice'] = (bool) $summary['display_notice'];
+    $summary['model'] = $summary['model'] !== '' ? sanitize_text_field((string) $summary['model']) : '';
+    $summary['temperature'] = $summary['temperature'] !== null ? (float) $summary['temperature'] : null;
+    $summary['max_tokens'] = $summary['max_tokens'] !== null ? max(0, (int) $summary['max_tokens']) : null;
+    $summary['post_id'] = (int) $summary['post_id'];
 
     return $summary;
 }


### PR DESCRIPTION
## Summary
- replace AI scaffolding with OpenAI chat completions integration, prompt templates, sanitization helpers, and request logging
- update AI AJAX endpoints to call the real generator, enforce limits, and surface connection test results
- polish admin UX by flagging filled AI fields and extend the debug page with last request metadata

## Testing
- php -l core/ai.php
- php -l admin/ajax/ai.php
- php -l admin/pages/debug.php

------
https://chatgpt.com/codex/tasks/task_e_68d3f8c0e9d083278acb1666f60752d3