### PR TITLE
Improve AI settings grid layout responsiveness

### DIFF
--- a/admin/pages/module-ai.php
+++ b/admin/pages/module-ai.php
@@ -55,16 +55,16 @@ function hr_sa_render_module_ai_page(): void
                                 </label>
                                 <p class="description hr-sa-ai-hint"><?php esc_html_e('Admin-only. No front-end API calls will ever occur.', HR_SA_TEXT_DOMAIN); ?></p>
                                 <div class="hr-sa-ai-settings">
-                                    <div class="hr-sa-ai-settings__field">
+                                    <div class="hr-sa-ai-settings__field hr-sa-ai-settings__field--full">
                                         <label for="hr_sa_ai_api_key"><?php esc_html_e('API Key', HR_SA_TEXT_DOMAIN); ?></label>
                                         <input type="password" id="hr_sa_ai_api_key" name="hr_sa_ai_api_key" value="<?php echo esc_attr($view['ai_key_masked']); ?>" class="regular-text" autocomplete="off" />
                                     </div>
-                                    <div class="hr-sa-ai-settings__field">
+                                    <div class="hr-sa-ai-settings__field hr-sa-ai-settings__field--full">
                                         <label for="hr_sa_ai_global_instructions"><?php esc_html_e('Global AI Instructions', HR_SA_TEXT_DOMAIN); ?></label>
                                         <textarea id="hr_sa_ai_global_instructions" name="hr_sa_ai_global_instructions" rows="5" class="large-text code"><?php echo esc_textarea($global_instructions); ?></textarea>
                                         <p class="description"><?php esc_html_e('Optional guidance sent with every AI request. Use this to enforce tone, disclaimers, or topics to avoid.', HR_SA_TEXT_DOMAIN); ?></p>
                                     </div>
-                                    <div class="hr-sa-ai-settings__field">
+                                    <div class="hr-sa-ai-settings__field hr-sa-ai-settings__field--full">
                                         <label for="hr_sa_ai_model"><?php esc_html_e('Model', HR_SA_TEXT_DOMAIN); ?></label>
                                         <input type="text" id="hr_sa_ai_model" name="hr_sa_ai_model" value="<?php echo esc_attr($ai_settings['hr_sa_ai_model']); ?>" class="regular-text" />
                                         <p class="description"><?php esc_html_e('Provider-specific identifier (e.g., gpt-4o-mini). Choose a model that supports chat completions.', HR_SA_TEXT_DOMAIN); ?></p>

--- a/admin/pages/settings.php
+++ b/admin/pages/settings.php
@@ -174,16 +174,16 @@ function hr_sa_render_settings_page(): void
                                 </label>
                                 <p class="description hr-sa-ai-hint"><?php esc_html_e('Admin-only. No front-end API calls will ever occur.', HR_SA_TEXT_DOMAIN); ?></p>
                                 <div class="hr-sa-ai-settings">
-                                    <div class="hr-sa-ai-settings__field">
+                                    <div class="hr-sa-ai-settings__field hr-sa-ai-settings__field--full">
                                         <label for="hr_sa_ai_api_key"><?php esc_html_e('API Key', HR_SA_TEXT_DOMAIN); ?></label>
                                         <input type="password" id="hr_sa_ai_api_key" name="hr_sa_ai_api_key" value="<?php echo esc_attr($ai_has_key ? $ai_key_masked : ''); ?>" class="regular-text" autocomplete="off" />
                                     </div>
-                                    <div class="hr-sa-ai-settings__field">
+                                    <div class="hr-sa-ai-settings__field hr-sa-ai-settings__field--full">
                                         <label for="hr_sa_ai_global_instructions"><?php esc_html_e('Global AI Instructions', HR_SA_TEXT_DOMAIN); ?></label>
                                         <textarea id="hr_sa_ai_global_instructions" name="hr_sa_ai_global_instructions" rows="5" class="large-text code"><?php echo esc_textarea($ai_global_instructions); ?></textarea>
                                         <p class="description"><?php esc_html_e('Optional guidance sent with every AI request. Use this to enforce tone, disclaimers, or topics to avoid.', HR_SA_TEXT_DOMAIN); ?></p>
                                     </div>
-                                    <div class="hr-sa-ai-settings__field">
+                                    <div class="hr-sa-ai-settings__field hr-sa-ai-settings__field--full">
                                         <label for="hr_sa_ai_model"><?php esc_html_e('Model', HR_SA_TEXT_DOMAIN); ?></label>
                                         <input type="text" id="hr_sa_ai_model" name="hr_sa_ai_model" value="<?php echo esc_attr($ai_model); ?>" class="regular-text" />
                                         <p class="description"><?php esc_html_e('Provider-specific identifier (e.g., gpt-4o-mini). Choose a model that supports chat completions.', HR_SA_TEXT_DOMAIN); ?></p>

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -118,7 +118,11 @@
     display: grid;
     gap: 12px;
     margin: 12px 0;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.hr-sa-ai-settings__field--full {
+    grid-column: 1 / -1;
 }
 
 .hr-sa-ai-settings__field label {
@@ -142,6 +146,12 @@
 
 .hr-sa-ai-test-result[data-state="error"] {
     color: #b32d2e;
+}
+
+@media (max-width: 782px) {
+    .hr-sa-ai-settings {
+        grid-template-columns: 1fr;
+    }
 }
 
 .hr-sa-btn-loading {


### PR DESCRIPTION
## Summary
- allow the AI API key, global instructions, and model fields to span the full grid width on both admin screens
- update the AI settings grid to use a two-column layout with a full-width modifier class and responsive stacking behaviour

## Testing
- Not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d7f9ce7de88327b1fdb6711453dbcd