### PR TITLE
Add JSON-LD preview tooling to module admin screen

### DIFF
--- a/admin/ajax/jsonld-preview.php
+++ b/admin/ajax/jsonld-preview.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * AJAX handler for JSON-LD previews.
+ *
+ * @package HR_SEO_Assistant
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+add_action('wp_ajax_hr_sa_jsonld_preview', 'hr_sa_handle_jsonld_preview');
+
+/**
+ * Handle the JSON-LD preview request.
+ */
+function hr_sa_handle_jsonld_preview(): void
+{
+    if (!current_user_can('manage_options')) {
+        wp_send_json_error(
+            ['message' => __('You do not have permission to run this preview.', HR_SA_TEXT_DOMAIN)],
+            403
+        );
+    }
+
+    $nonce = isset($_POST['nonce']) ? sanitize_text_field(wp_unslash((string) $_POST['nonce'])) : '';
+    if (!wp_verify_nonce($nonce, 'hr_sa_jsonld_preview')) {
+        wp_send_json_error(
+            ['message' => __('Your session has expired. Refresh the page and try again.', HR_SA_TEXT_DOMAIN)],
+            400
+        );
+    }
+
+    $target = isset($_POST['target']) ? absint((string) wp_unslash($_POST['target'])) : 0;
+
+    $context = hr_sa_jsonld_preview_prepare_context($target);
+    if (is_wp_error($context)) {
+        wp_send_json_error(
+            ['message' => $context->get_error_message()],
+            400
+        );
+    }
+
+    $restore = $context['restore'];
+
+    $original_emitters = $GLOBALS['hr_sa_jsonld_last_active_emitters'] ?? [];
+    $rows              = [];
+    $json              = '';
+
+    try {
+        $graph = hr_sa_jsonld_collect_graph();
+        $graph = hr_sa_jsonld_normalize_internal_urls($graph);
+        $graph = hr_sa_jsonld_enforce_org_and_brand($graph);
+        $graph = hr_sa_jsonld_dedupe_by_id($graph);
+
+        $graph = apply_filters('hr_sa_jsonld_graph_nodes', $graph);
+        $graph = hr_sa_jsonld_normalize_internal_urls($graph);
+        $graph = hr_sa_jsonld_enforce_org_and_brand($graph);
+        $graph = hr_sa_jsonld_dedupe_by_id($graph);
+
+        $payload = [
+            '@context' => 'https://schema.org',
+            '@graph'   => array_values($graph),
+        ];
+
+        $rows = hr_sa_jsonld_preview_flatten($payload);
+        $json = wp_json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (!is_string($json)) {
+            $json = '{}';
+        }
+    } finally {
+        $GLOBALS['hr_sa_jsonld_last_active_emitters'] = $original_emitters;
+        if (is_callable($restore)) {
+            $restore();
+        }
+    }
+
+    wp_send_json_success(
+        [
+            'rows' => $rows,
+            'json' => $json,
+        ]
+    );
+}
+
+/**
+ * Prepare a temporary WP_Query context for the requested preview target.
+ *
+ * @return array{
+ *     query: WP_Query,
+ *     restore: callable,
+ * }|WP_Error
+ */
+function hr_sa_jsonld_preview_prepare_context(int $target)
+{
+    global $wp_query, $wp_the_query, $post;
+
+    $original_wp_query     = $wp_query;
+    $original_wp_the_query = $wp_the_query;
+    $original_post         = $post ?? null;
+
+    $query = null;
+
+    if ($target === 0) {
+        $show_on_front = get_option('show_on_front', 'posts');
+        if ($show_on_front === 'page') {
+            $front_id = (int) get_option('page_on_front');
+            if ($front_id > 0) {
+                $query = new WP_Query([
+                    'page_id'        => $front_id,
+                    'post_type'      => 'page',
+                    'post_status'    => 'publish',
+                    'posts_per_page' => 1,
+                ]);
+                $query->is_front_page = true;
+                $query->is_home       = false;
+            }
+        }
+
+        if (!$query instanceof WP_Query) {
+            $query = new WP_Query([
+                'post_type'      => 'post',
+                'post_status'    => 'publish',
+                'posts_per_page' => max(1, (int) get_option('posts_per_page', 5)),
+            ]);
+            $query->is_front_page = true;
+            $query->is_home       = true;
+        }
+    } else {
+        $post_object = get_post($target);
+        if (!$post_object || $post_object->post_status !== 'publish') {
+            return new WP_Error('hr_sa_jsonld_preview_missing', __('The selected item is not available.', HR_SA_TEXT_DOMAIN));
+        }
+
+        $query = new WP_Query([
+            'p'              => $post_object->ID,
+            'post_type'      => $post_object->post_type,
+            'post_status'    => 'publish',
+            'posts_per_page' => 1,
+        ]);
+        $query->is_singular = true;
+        $query->is_page     = $post_object->post_type === 'page';
+        $query->is_single   = $post_object->post_type === 'post';
+    }
+
+    if (!$query instanceof WP_Query) {
+        return new WP_Error('hr_sa_jsonld_preview_failed', __('Unable to prepare the preview context.', HR_SA_TEXT_DOMAIN));
+    }
+
+    if ($query->have_posts()) {
+        $query->the_post();
+    }
+
+    $wp_query     = $query;
+    $wp_the_query = $query;
+    $post         = $query->post ?? null;
+
+    return [
+        'query'   => $query,
+        'restore' => static function () use ($original_wp_query, $original_wp_the_query, $original_post): void {
+            global $wp_query, $wp_the_query, $post;
+            $wp_query     = $original_wp_query;
+            $wp_the_query = $original_wp_the_query;
+            $post         = $original_post;
+        },
+    ];
+}
+
+/**
+ * Flatten the JSON-LD payload into label/value rows for display.
+ *
+ * @param mixed  $data   Data to flatten.
+ * @param string $prefix Current property path.
+ *
+ * @return array<int, array{label: string, value: string}>
+ */
+function hr_sa_jsonld_preview_flatten($data, string $prefix = ''): array
+{
+    $rows = [];
+
+    if (is_object($data)) {
+        $data = (array) $data;
+    }
+
+    if (is_array($data)) {
+        $is_assoc = array_keys($data) !== range(0, count($data) - 1);
+        foreach ($data as $key => $value) {
+            $segment = $is_assoc ? (string) $key : '[' . $key . ']';
+            $label   = $prefix === '' ? $segment : $prefix . ' › ' . $segment;
+            $rows    = array_merge($rows, hr_sa_jsonld_preview_flatten($value, $label));
+        }
+        return $rows;
+    }
+
+    if (is_bool($data)) {
+        $value = $data ? __('true', HR_SA_TEXT_DOMAIN) : __('false', HR_SA_TEXT_DOMAIN);
+    } elseif ($data === null) {
+        $value = __('null', HR_SA_TEXT_DOMAIN);
+    } else {
+        $value = (string) $data;
+    }
+
+    $rows[] = [
+        'label' => $prefix === '' ? __('Value', HR_SA_TEXT_DOMAIN) : $prefix,
+        'value' => $value,
+    ];
+
+    return $rows;
+}

--- a/admin/pages/module-jsonld.php
+++ b/admin/pages/module-jsonld.php
@@ -33,6 +33,29 @@ function hr_sa_render_module_jsonld_page(): void
         <?php if (!$module_enabled) : ?>
             <div class="notice notice-warning"><p><?php esc_html_e('This module is disabled. Enable it from the HR SEO Overview to resume schema output.', HR_SA_TEXT_DOMAIN); ?></p></div>
         <?php endif; ?>
+        <?php wp_nonce_field('hr_sa_jsonld_preview', 'hr_sa_jsonld_preview_nonce', false); ?>
+        <h2><?php esc_html_e('Preview Structured Data', HR_SA_TEXT_DOMAIN); ?></h2>
+        <p class="description">
+            <?php esc_html_e('Inspect the JSON-LD payload for the homepage or a recent piece of content without visiting the public site.', HR_SA_TEXT_DOMAIN); ?>
+        </p>
+        <div class="hr-sa-jsonld-preview" data-hr-sa-jsonld-preview>
+            <div class="hr-sa-jsonld-preview__controls">
+                <label class="screen-reader-text" for="hr-sa-jsonld-preview-target">
+                    <?php esc_html_e('Select a preview target', HR_SA_TEXT_DOMAIN); ?>
+                </label>
+                <select id="hr-sa-jsonld-preview-target" class="hr-sa-jsonld-preview__select" data-hr-sa-jsonld-preview-select>
+                    <option value="0" selected="selected"><?php esc_html_e('Home', HR_SA_TEXT_DOMAIN); ?></option>
+                </select>
+            </div>
+            <div class="hr-sa-jsonld-preview__status" data-hr-sa-jsonld-preview-status></div>
+            <div class="hr-sa-jsonld-preview__table" data-hr-sa-jsonld-preview-table></div>
+            <div class="hr-sa-jsonld-preview__raw">
+                <label for="hr-sa-jsonld-preview-json" class="hr-sa-jsonld-preview__raw-label">
+                    <?php esc_html_e('JSON Output', HR_SA_TEXT_DOMAIN); ?>
+                </label>
+                <textarea id="hr-sa-jsonld-preview-json" class="hr-sa-jsonld-preview__raw-field" data-hr-sa-jsonld-preview-json readonly rows="10"></textarea>
+            </div>
+        </div>
         <h2><?php esc_html_e('Active Emitters (last request)', HR_SA_TEXT_DOMAIN); ?></h2>
         <?php if (empty($emitters)) : ?>
             <p><?php esc_html_e('No emitters have produced nodes during the last run or JSON-LD is disabled.', HR_SA_TEXT_DOMAIN); ?></p>

--- a/assets/module-jsonld.js
+++ b/assets/module-jsonld.js
@@ -1,0 +1,283 @@
+(() => {
+    const wpGlobal = window.wp || {};
+    const __ = wpGlobal.i18n && typeof wpGlobal.i18n.__ === 'function'
+        ? wpGlobal.i18n.__
+        : (text) => text;
+
+    const config = window.hrSaJsonLdPreview || null;
+    if (!config || typeof config !== 'object') {
+        return;
+    }
+
+    const root = document.querySelector('[data-hr-sa-jsonld-preview]');
+    if (!root) {
+        return;
+    }
+
+    const select = root.querySelector('[data-hr-sa-jsonld-preview-select]');
+    const status = root.querySelector('[data-hr-sa-jsonld-preview-status]');
+    const tableContainer = root.querySelector('[data-hr-sa-jsonld-preview-table]');
+    const jsonField = root.querySelector('[data-hr-sa-jsonld-preview-json]');
+
+    const targets = Array.isArray(config.targets) ? config.targets : [];
+    const defaultTarget = typeof config.defaultTarget === 'number'
+        ? String(config.defaultTarget)
+        : String(config.defaultTarget || '0');
+
+    const getMessage = (key, fallback) => {
+        if (!config.messages || typeof config.messages !== 'object') {
+            return fallback;
+        }
+        const value = config.messages[key];
+        return typeof value === 'string' && value !== '' ? value : fallback;
+    };
+
+    const setStatus = (message, state = '') => {
+        if (!status) {
+            return;
+        }
+
+        const text = typeof message === 'string' ? message : '';
+        status.textContent = text;
+        if (text === '') {
+            status.setAttribute('hidden', 'hidden');
+        } else {
+            status.removeAttribute('hidden');
+        }
+
+        if (state) {
+            status.setAttribute('data-state', state);
+        } else {
+            status.removeAttribute('data-state');
+        }
+    };
+
+    const clearTable = () => {
+        if (tableContainer) {
+            tableContainer.innerHTML = '';
+        }
+    };
+
+    const renderJson = (content) => {
+        if (!jsonField) {
+            return;
+        }
+
+        const text = typeof content === 'string' ? content : '';
+        jsonField.value = text !== '' ? text : getMessage('jsonEmpty', '');
+    };
+
+    const renderRows = (rows) => {
+        clearTable();
+
+        if (!Array.isArray(rows) || rows.length === 0) {
+            setStatus(getMessage('empty', __('No JSON-LD nodes were generated for this selection.', 'hr-seo-assistant')), 'info');
+            return;
+        }
+
+        const table = document.createElement('table');
+        table.className = 'widefat hr-sa-jsonld-preview__table-grid';
+
+        const thead = document.createElement('thead');
+        const headerRow = document.createElement('tr');
+
+        const thKey = document.createElement('th');
+        thKey.scope = 'col';
+        thKey.textContent = getMessage('tableKey', __('Property', 'hr-seo-assistant'));
+
+        const thValue = document.createElement('th');
+        thValue.scope = 'col';
+        thValue.textContent = getMessage('tableValue', __('Value', 'hr-seo-assistant'));
+
+        headerRow.appendChild(thKey);
+        headerRow.appendChild(thValue);
+        thead.appendChild(headerRow);
+        table.appendChild(thead);
+
+        const tbody = document.createElement('tbody');
+
+        rows.forEach((row) => {
+            if (!row || typeof row !== 'object') {
+                return;
+            }
+
+            const label = typeof row.label === 'string' ? row.label : '';
+            const value = typeof row.value === 'string' ? row.value : '';
+
+            const tr = document.createElement('tr');
+
+            const th = document.createElement('th');
+            th.scope = 'row';
+            th.textContent = label;
+
+            const td = document.createElement('td');
+            td.textContent = value;
+
+            tr.appendChild(th);
+            tr.appendChild(td);
+            tbody.appendChild(tr);
+        });
+
+        table.appendChild(tbody);
+
+        if (tableContainer) {
+            tableContainer.appendChild(table);
+        }
+
+        setStatus('', 'success');
+    };
+
+    const populateTargets = () => {
+        if (!select || targets.length === 0) {
+            return;
+        }
+
+        select.innerHTML = '';
+
+        targets.forEach((target) => {
+            if (!target || typeof target !== 'object') {
+                return;
+            }
+
+            const value = typeof target.id === 'number' || typeof target.id === 'string'
+                ? String(target.id)
+                : '';
+
+            if (value === '') {
+                return;
+            }
+
+            const label = typeof target.label === 'string' ? target.label : value;
+            const type  = typeof target.type === 'string' && target.type !== '' ? target.type : '';
+
+            const option = document.createElement('option');
+            option.value = value;
+            option.textContent = type !== '' ? `${label} (${type})` : label;
+            if (value === defaultTarget) {
+                option.selected = true;
+            }
+
+            select.appendChild(option);
+        });
+
+        if (!select.querySelector('option[selected]') && select.options.length > 0) {
+            select.options[0].selected = true;
+        }
+    };
+
+    let activeController = null;
+
+    const loadPreview = (targetValue) => {
+        const ajaxUrl = typeof config.ajaxUrl === 'string' ? config.ajaxUrl : '';
+        const nonce = typeof config.nonce === 'string' ? config.nonce : '';
+
+        if (!ajaxUrl) {
+            setStatus(__('The AJAX endpoint is not available.', 'hr-seo-assistant'), 'error');
+            return;
+        }
+
+        if (activeController && typeof activeController.abort === 'function') {
+            activeController.abort();
+        }
+
+        const controller = typeof AbortController === 'function' ? new AbortController() : null;
+        activeController = controller;
+
+        setStatus(getMessage('loading', __('Loading preview…', 'hr-seo-assistant')), 'loading');
+        clearTable();
+        renderJson('');
+
+        const params = new URLSearchParams();
+        params.append('action', 'hr_sa_jsonld_preview');
+        params.append('nonce', nonce);
+        params.append('target', String(targetValue));
+
+        const fetchOptions = {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            },
+            body: params.toString(),
+        };
+
+        if (controller && controller.signal) {
+            fetchOptions.signal = controller.signal;
+        }
+
+        window.fetch(ajaxUrl, fetchOptions)
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error('request_failed');
+                }
+                return response.json();
+            })
+            .then((payload) => {
+                if (controller && activeController !== controller) {
+                    return;
+                }
+
+                if (!payload || typeof payload !== 'object') {
+                    throw new Error('invalid_response');
+                }
+
+                if (!payload.success) {
+                    const message = payload.data && typeof payload.data.message === 'string'
+                        ? payload.data.message
+                        : getMessage('error', __('We could not load the preview. Please try again.', 'hr-seo-assistant'));
+                    throw new Error(message);
+                }
+
+                const data = payload.data || {};
+                renderRows(data.rows);
+                renderJson(data.json);
+
+                if (data.rows && Array.isArray(data.rows) && data.rows.length === 0) {
+                    setStatus(getMessage('empty', __('No JSON-LD nodes were generated for this selection.', 'hr-seo-assistant')), 'info');
+                }
+            })
+            .catch((error) => {
+                if (controller && typeof error === 'object' && error.name === 'AbortError') {
+                    return;
+                }
+
+                const message = typeof error === 'string'
+                    ? error
+                    : (error && typeof error.message === 'string' && error.message !== 'request_failed' && error.message !== 'invalid_response'
+                        ? error.message
+                        : getMessage('error', __('We could not load the preview. Please try again.', 'hr-seo-assistant')));
+                setStatus(message, 'error');
+                clearTable();
+                renderJson('');
+            })
+            .finally(() => {
+                if (activeController === controller) {
+                    activeController = null;
+                }
+            });
+    };
+
+    if (jsonField) {
+        jsonField.value = getMessage('jsonEmpty', '');
+    }
+
+    populateTargets();
+
+    const initialMessage = getMessage('ready', __('Select an item to load its JSON-LD.', 'hr-seo-assistant'));
+    setStatus(initialMessage, 'info');
+
+    if (select) {
+        select.addEventListener('change', (event) => {
+            const value = event.target && typeof event.target.value === 'string'
+                ? event.target.value
+                : defaultTarget;
+            loadPreview(value);
+        });
+    }
+
+    const initialValue = select && typeof select.value === 'string' && select.value !== ''
+        ? select.value
+        : defaultTarget;
+
+    loadPreview(initialValue);
+})();

--- a/hr-seo-assistant.php
+++ b/hr-seo-assistant.php
@@ -36,6 +36,7 @@ require_once HR_SA_PLUGIN_DIR . 'admin/pages/module-open-graph.php';
 require_once HR_SA_PLUGIN_DIR . 'admin/pages/module-ai.php';
 require_once HR_SA_PLUGIN_DIR . 'admin/meta-boxes/ai.php';
 require_once HR_SA_PLUGIN_DIR . 'admin/ajax/ai.php';
+require_once HR_SA_PLUGIN_DIR . 'admin/ajax/jsonld-preview.php';
 require_once HR_SA_PLUGIN_DIR . 'admin/ajax/modules.php';
 require_once HR_SA_PLUGIN_DIR . 'admin/menu.php';
 require_once HR_SA_PLUGIN_DIR . 'modules/meta/seo.php';


### PR DESCRIPTION
## Summary
- add a structured-data preview UI to the JSON-LD module page with selector, status, and raw output areas
- introduce an authenticated AJAX endpoint that hydrates a temporary query, runs the JSON-LD pipeline, and returns flattened preview data
- enqueue a module-specific script that populates selector options, calls the preview endpoint, and renders the results

## Testing
- php -l admin/ajax/jsonld-preview.php
- php -l admin/menu.php
- php -l admin/pages/module-jsonld.php

------
https://chatgpt.com/codex/tasks/task_e_68d801054a98832793dc5dfbdc3e97be