### PR TITLE
Fix JSON-LD preview type normalization

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -121,6 +121,13 @@ Rename MU files back to `*.php` so production behavior is unchanged until we shi
 - **Debug** page shows JSON-LD module enabled, OG disabled.
 - No PHP notices/fatals in error logs during page loads.
 
+---
+
+## Regression — JSON-LD preview Type labels
+1. Navigate to **HR SEO → JSON-LD Preview**.
+2. Trigger a preview for any page and focus on the **Type** column.
+3. Confirm that entries whose context or type equals `https://schema.org/` now display as **Schema.org** (humanized host) instead of showing a blank label.
+
 ✅ **Phase 0 is complete** when:
 - JSON-LD parity is verified on the three page types.
 - Admin UI & Debug behave correctly.

--- a/admin/ajax/jsonld-preview.php
+++ b/admin/ajax/jsonld-preview.php
@@ -286,26 +286,57 @@ function hr_sa_jsonld_preview_flatten($data): array
             }
 
             $value = $decode_value($value);
+            $candidate = $value;
+            $parsed_host = '';
 
             if (strpos($value, '://') !== false) {
                 $parsed = wp_parse_url($value);
                 if (is_array($parsed)) {
-                    if (!empty($parsed['path'])) {
-                        $value = trim((string) $parsed['path'], '/');
-                    } elseif (!empty($parsed['host'])) {
-                        $value = $parsed['host'];
+                    $parsed_host = isset($parsed['host']) ? (string) $parsed['host'] : '';
+                    $path = isset($parsed['path']) ? trim((string) $parsed['path'], '/') : '';
+
+                    if ($path !== '') {
+                        $candidate = $path;
+                    } elseif ($parsed_host !== '') {
+                        $candidate = $parsed_host;
+                    } elseif ($fallback !== '') {
+                        $candidate = $fallback;
+                    } else {
+                        $candidate = '';
                     }
                 }
             }
 
-            $label = $humanize_segment($value);
+            if ($candidate === '' && $fallback !== '') {
+                $candidate = $fallback;
+            }
+
+            if ($candidate === '') {
+                continue;
+            }
+
+            $label = $humanize_segment($candidate);
+            if ($label === '' && $parsed_host !== '') {
+                $label = $humanize_segment($parsed_host);
+                if ($label === '') {
+                    $label = $parsed_host;
+                }
+            }
+
+            if ($label === '' && $fallback !== '') {
+                $fallback_label = $humanize_segment($fallback);
+                $label = $fallback_label !== '' ? $fallback_label : $fallback;
+            }
+
             if ($label !== '') {
                 $labels[] = $label;
             }
         }
 
         if (empty($labels) && $fallback !== '') {
-            return $fallback;
+            $fallback_label = $humanize_segment($fallback);
+
+            return $fallback_label !== '' ? $fallback_label : $fallback;
         }
 
         if (empty($labels)) {


### PR DESCRIPTION
## Summary
- ensure JSON-LD preview type normalization falls back to URL hosts or provided labels before humanizing them
- document a regression check confirming schema.org URLs now appear in the preview type column

## Testing
- php -l admin/ajax/jsonld-preview.php

------
https://chatgpt.com/codex/tasks/task_e_68d80b740d64832790ff9af2160f053c