### PR TITLE
Simplify Open Graph admin preview to single image

### DIFF
--- a/admin/menu.php
+++ b/admin/menu.php
@@ -177,7 +177,6 @@ function hr_sa_enqueue_admin_assets(string $hook_suffix): void
                     'ogDisabled'      => __('Open Graph tags are disabled for this selection.', HR_SA_TEXT_DOMAIN),
                     'twitterDisabled' => __('Twitter Card tags are disabled for this selection.', HR_SA_TEXT_DOMAIN),
                     'ready'           => __('Preview loaded.', HR_SA_TEXT_DOMAIN),
-                    'cardType'        => __('Twitter Card type: %s', HR_SA_TEXT_DOMAIN),
                     'imageAlt'        => __('Preview image', HR_SA_TEXT_DOMAIN),
                     'optionFormat'    => __('%1$s — %2$s', HR_SA_TEXT_DOMAIN),
                 ],

--- a/admin/pages/module-open-graph.php
+++ b/admin/pages/module-open-graph.php
@@ -230,92 +230,10 @@ function hr_sa_render_module_open_graph_page(): void
                     <?php endif; ?>
                 </div>
                 <div class="hr-sa-og-preview__status" aria-live="polite"></div>
-                <div class="hr-sa-og-preview__grid" data-hr-sa-og-preview-grid>
-                    <article class="hr-sa-og-card hr-sa-og-card--facebook" data-platform="facebook">
-                        <header class="hr-sa-og-card__header"><?php esc_html_e('Facebook (OG)', HR_SA_TEXT_DOMAIN); ?></header>
-                        <div class="hr-sa-og-card__media">
-                            <img src="" alt="" loading="lazy" class="hr-sa-og-card__image" />
-                        </div>
-                        <div class="hr-sa-og-card__body">
-                            <div class="hr-sa-og-card__meta">
-                                <span class="hr-sa-og-card__site"></span>
-                                <span class="hr-sa-og-card__url"></span>
-                            </div>
-                            <h3 class="hr-sa-og-card__title"></h3>
-                            <p class="hr-sa-og-card__description"></p>
-                        </div>
-                    </article>
-                    <article class="hr-sa-og-card hr-sa-og-card--linkedin" data-platform="linkedin">
-                        <header class="hr-sa-og-card__header"><?php esc_html_e('LinkedIn (OG)', HR_SA_TEXT_DOMAIN); ?></header>
-                        <div class="hr-sa-og-card__media">
-                            <img src="" alt="" loading="lazy" class="hr-sa-og-card__image" />
-                        </div>
-                        <div class="hr-sa-og-card__body">
-                            <div class="hr-sa-og-card__meta">
-                                <span class="hr-sa-og-card__site"></span>
-                                <span class="hr-sa-og-card__url"></span>
-                            </div>
-                            <h3 class="hr-sa-og-card__title"></h3>
-                            <p class="hr-sa-og-card__description"></p>
-                        </div>
-                    </article>
-                    <article class="hr-sa-og-card hr-sa-og-card--twitter" data-platform="twitter">
-                        <header class="hr-sa-og-card__header"><?php esc_html_e('Twitter / X (Twitter Card)', HR_SA_TEXT_DOMAIN); ?></header>
-                        <div class="hr-sa-og-card__media">
-                            <img src="" alt="" loading="lazy" class="hr-sa-og-card__image" />
-                        </div>
-                        <div class="hr-sa-og-card__body">
-                            <div class="hr-sa-og-card__meta">
-                                <span class="hr-sa-og-card__site"></span>
-                                <span class="hr-sa-og-card__url"></span>
-                            </div>
-                            <h3 class="hr-sa-og-card__title"></h3>
-                            <p class="hr-sa-og-card__description"></p>
-                        </div>
-                    </article>
-                    <article class="hr-sa-og-card hr-sa-og-card--discord" data-platform="discord">
-                        <header class="hr-sa-og-card__header"><?php esc_html_e('Discord (OG embed)', HR_SA_TEXT_DOMAIN); ?></header>
-                        <div class="hr-sa-og-card__media">
-                            <img src="" alt="" loading="lazy" class="hr-sa-og-card__image" />
-                        </div>
-                        <div class="hr-sa-og-card__body">
-                            <div class="hr-sa-og-card__meta">
-                                <span class="hr-sa-og-card__site"></span>
-                                <span class="hr-sa-og-card__url"></span>
-                            </div>
-                            <h3 class="hr-sa-og-card__title"></h3>
-                            <p class="hr-sa-og-card__description"></p>
-                        </div>
-                    </article>
-                    <article class="hr-sa-og-card hr-sa-og-card--slack" data-platform="slack">
-                        <header class="hr-sa-og-card__header"><?php esc_html_e('Slack (OG)', HR_SA_TEXT_DOMAIN); ?></header>
-                        <div class="hr-sa-og-card__media">
-                            <img src="" alt="" loading="lazy" class="hr-sa-og-card__image" />
-                        </div>
-                        <div class="hr-sa-og-card__body">
-                            <div class="hr-sa-og-card__meta">
-                                <span class="hr-sa-og-card__site"></span>
-                                <span class="hr-sa-og-card__url"></span>
-                            </div>
-                            <h3 class="hr-sa-og-card__title"></h3>
-                            <p class="hr-sa-og-card__description"></p>
-                        </div>
-                    </article>
-                    <article class="hr-sa-og-card hr-sa-og-card--whatsapp" data-platform="whatsapp">
-                        <header class="hr-sa-og-card__header"><?php esc_html_e('WhatsApp (OG)', HR_SA_TEXT_DOMAIN); ?></header>
-                        <div class="hr-sa-og-card__media">
-                            <img src="" alt="" loading="lazy" class="hr-sa-og-card__image" />
-                        </div>
-                        <div class="hr-sa-og-card__body">
-                            <div class="hr-sa-og-card__meta">
-                                <span class="hr-sa-og-card__site"></span>
-                                <span class="hr-sa-og-card__url"></span>
-                            </div>
-                            <h3 class="hr-sa-og-card__title"></h3>
-                            <p class="hr-sa-og-card__description"></p>
-                        </div>
-                    </article>
-                </div>
+                <figure class="hr-sa-og-preview__image" data-hr-sa-og-preview-image>
+                    <img src="" alt="" loading="lazy" width="600" height="315" />
+                    <figcaption class="hr-sa-og-preview__image-caption"><?php esc_html_e('Preview image (600×315)', HR_SA_TEXT_DOMAIN); ?></figcaption>
+                </figure>
                 <table class="widefat fixed striped hr-sa-og-preview__table">
                     <thead>
                         <tr>

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -230,92 +230,33 @@
     color: #50575e;
 }
 
-.hr-sa-og-preview__grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 16px;
-    margin-bottom: 24px;
-}
-
-.hr-sa-og-card {
-    border: 1px solid #dcdcde;
-    border-radius: 8px;
-    background: #fff;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-    overflow: hidden;
+.hr-sa-og-preview__image {
+    margin: 0 0 24px;
     display: flex;
     flex-direction: column;
-    min-height: 100%;
+    gap: 12px;
+    align-items: flex-start;
 }
 
-.hr-sa-og-card__header {
-    margin: 0;
-    padding: 12px 16px;
-    background: #f6f7f7;
-    font-size: 13px;
-    font-weight: 600;
-    color: #2c3338;
-}
-
-.hr-sa-og-card__media {
-    position: relative;
-    padding-top: 52.5%;
-    background: #f0f0f1;
-}
-
-.hr-sa-og-card__image {
-    position: absolute;
-    top: 0;
-    left: 0;
+.hr-sa-og-preview__image img {
     width: 100%;
-    height: 100%;
+    max-width: 600px;
+    aspect-ratio: 600 / 315;
+    height: auto;
     object-fit: cover;
+    border: 1px solid #dcdcde;
+    border-radius: 6px;
     background: #f0f0f1;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
-.hr-sa-og-card__body {
-    padding: 16px;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    flex: 1 1 auto;
-}
-
-.hr-sa-og-card__meta {
-    display: flex;
-    justify-content: space-between;
-    gap: 8px;
-    font-size: 12px;
+.hr-sa-og-preview__image-caption {
+    margin: 0;
+    font-size: 13px;
     color: #50575e;
 }
 
-.hr-sa-og-card__site {
-    font-weight: 600;
-    text-transform: uppercase;
-}
-
-.hr-sa-og-card__url {
-    overflow-wrap: anywhere;
-}
-
-.hr-sa-og-card__title {
-    font-size: 15px;
-    margin: 0;
-    color: #1d2327;
-}
-
-.hr-sa-og-card__description {
-    margin: 0;
-    color: #2c3338;
-    font-size: 13px;
-    line-height: 1.5;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-}
-
-.hr-sa-og-preview.is-loading .hr-sa-og-card {
+.hr-sa-og-preview.is-loading .hr-sa-og-preview__image img {
     opacity: 0.6;
 }
 
@@ -339,8 +280,8 @@
         top: 0;
     }
 
-    .hr-sa-og-preview__grid {
-        grid-template-columns: 1fr;
+    .hr-sa-og-preview__image {
+        align-items: stretch;
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the Open Graph preview grid with a single image figure above the property table
- update the preview script to populate the lone image and remove unused Twitter card messaging
- streamline admin styles for the new preview layout and size constraints

## Testing
- php -l admin/pages/module-open-graph.php

------
https://chatgpt.com/codex/tasks/task_e_68d817fafeb48327a6ee66c39c463058