### PR TITLE
Align OG preview image with card edge

### DIFF
--- a/assets/admin.css
+++ b/assets/admin.css
@@ -239,8 +239,10 @@
 }
 
 .hr-sa-og-preview__image img {
-    width: 100%;
-    max-width: 600px;
+    display: block;
+    width: min(100% + 24px, 624px);
+    max-width: none;
+    margin-left: -24px;
     aspect-ratio: 600 / 315;
     height: auto;
     object-fit: cover;


### PR DESCRIPTION
## Summary
- offset the Open Graph preview image so it sits flush with the card edge
- allow the image to expand responsively without disturbing the existing caption spacing

## Testing
- Not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68d8223ce6cc832791ea6f3ccc114189