### PR TITLE
Refactor JSON-LD and OG emitters to rely solely on HRDF

### DIFF
--- a/core/hrdf.php
+++ b/core/hrdf.php
@@ -29,6 +29,46 @@ function hr_sa_hrdf_get(string $dot_path, int $post_id = 0, $default = null)
 }
 
 /**
+ * Retrieve the first non-empty value from a list of HRDF dot paths.
+ *
+ * @param array<int, string> $paths
+ * @param mixed              $default
+ * @return mixed
+ */
+function hr_sa_hrdf_get_first(array $paths, int $post_id = 0, $default = null)
+{
+    foreach ($paths as $path) {
+        $value = hr_sa_hrdf_get($path, $post_id, null);
+
+        if ($value === null) {
+            continue;
+        }
+
+        if (is_string($value)) {
+            if (trim($value) === '') {
+                continue;
+            }
+
+            return $value;
+        }
+
+        if (is_array($value)) {
+            if ($value === []) {
+                continue;
+            }
+
+            return $value;
+        }
+
+        if ($value !== '') {
+            return $value;
+        }
+    }
+
+    return $default;
+}
+
+/**
  * Retrieve the full HRDF document for the given post when available.
  *
  * @return array<string, mixed>

--- a/docs/hrdf-mapping.md
+++ b/docs/hrdf-mapping.md
@@ -1,0 +1,82 @@
+# HRDF Mapping Reference
+
+This table lists how HR SEO Assistant resolves Schema.org, Open Graph, and Twitter Card fields from the HR Data Framework (HRDF). Only the listed HRDF keys are consulted—if no value is present, the corresponding output is omitted.
+
+## JSON-LD (Organization / Website / WebPage)
+
+| Schema Field | HRDF Source Keys (checked in order) |
+| --- | --- |
+| Organization.name | `hrdf.org.name`, `hrdf.site.name` |
+| Organization.legalName | `hrdf.org.legalName` |
+| Organization.url | `hrdf.org.url`, `hrdf.site.url` |
+| Organization.logo | `hrdf.org.logo.url`, `hrdf.site.logo_url` |
+| Organization.priceRange | `hrdf.org.priceRange` |
+| Organization.vatID | `hrdf.org.vatId` |
+| Organization.registrationNumber | `hrdf.org.registrationNumber` |
+| Organization.sameAs | `hrdf.org.sameAs` |
+| Organization.contactPoint | `hrdf.org.contactPoints`, `hrdf.org.contactPoint` |
+| Organization.address | `hrdf.org.address` |
+| Organization.geo | `hrdf.org.geo` |
+| Organization.openingHoursSpecification | `hrdf.org.openingHours` |
+| WebSite.name | `hrdf.website.name`, `hrdf.site.name` |
+| WebSite.url | `hrdf.website.url`, `hrdf.site.url` |
+| WebSite.potentialAction.target | `hrdf.website.search_url_template`, `hrdf.site.search_url_template` |
+| WebSite.publishingPrinciples | `hrdf.policy.privacy_url`, `hrdf.policy.terms_url`, `hrdf.policy.refund_url` |
+| WebPage.name | `hrdf.webpage.title`, `hrdf.meta.title`, `hrdf.trip.title` |
+| WebPage.url | `hrdf.webpage.url`, `hrdf.meta.canonical_url`, `hrdf.trip.url` |
+| WebPage.description | `hrdf.webpage.description`, `hrdf.meta.description`, `hrdf.trip.description` |
+| WebPage.image / primaryImageOfPage | `hrdf.webpage.image`, `hrdf.webpage.images`, `hrdf.trip.images`, `hrdf.hero.image_url` |
+| WebPage.about | Derived from Organization `@id` (`hrdf.org.url` / `hrdf.site.url`) |
+
+## JSON-LD (Trip / Product Graph)
+
+| Schema Field | HRDF Source Keys (checked in order) |
+| --- | --- |
+| Product.name | `hrdf.trip.title`, `hrdf.webpage.title`, `hrdf.meta.title` |
+| Product.url | `hrdf.trip.url`, `hrdf.webpage.url`, `hrdf.meta.canonical_url` |
+| Product.description | `hrdf.trip.description`, `hrdf.webpage.description`, `hrdf.meta.description` |
+| Product.image[] | `hrdf.trip.images`, `hrdf.webpage.images`, `hrdf.hero.image_url`, `hrdf.gallery.images`, `hrdf.trip.gallery.images` |
+| Product.brand | Organization `@id` (`hrdf.org.url`, `hrdf.site.url`) |
+| Product.additionalProperty | `hrdf.trip.additionalProperty`, `hrdf.trip.properties` |
+| Offer[] | `hrdf.trip.offers`, `hrdf.offer.primary`, `hrdf.trip.vehicles[].offers`, `hrdf.bikes.offers` |
+| Offer price | `price.amount`, `price`, `priceAmount` within each offer |
+| Offer priceCurrency | `price.currency`, `priceCurrency` within each offer |
+| Offer availability | `availability` within each offer |
+| Offer inventoryLevel | `inventoryRemaining`, `inventory_remaining` within each offer |
+| Offer eligibleQuantity | `eligibleQuantity`, `eligible_quantity` within each offer |
+| Offer date windows | `priceValidFrom`, `valid_from`, `priceValidUntil`, `valid_until`, `availabilityEnds`, `validFrom`, `date` within each offer |
+| AggregateOffer | `hrdf.trip.aggregateOffer` |
+| Itinerary ItemList | `hrdf.trip.itinerary.steps`, `hrdf.itinerary.items` |
+| FAQPage | `hrdf.trip.faq.items`, `hrdf.faq.items` |
+| Reviews[] | `hrdf.trip.reviews`, `hrdf.reviews` |
+| AggregateRating | `hrdf.trip.aggregateRating`, `hrdf.aggregate_rating` |
+| Vehicles[] | `hrdf.trip.vehicles`, `hrdf.bikes.list` |
+| Vehicle offers[] | `hrdf.trip.vehicles[].offers`, `hrdf.bikes.offers` |
+| Stopovers ItemList | `hrdf.trip.stopovers`, `hrdf.stopovers.list` |
+| Guides Person[] | `hrdf.trip.guides`, `hrdf.guides.list` |
+
+## Open Graph
+
+| OG Field | HRDF Source Keys (checked in order) |
+| --- | --- |
+| og:title | `hrdf.webpage.title`, `hrdf.meta.title`, `hrdf.trip.title` |
+| og:description | `hrdf.webpage.description`, `hrdf.meta.description`, `hrdf.trip.description` |
+| og:url | `hrdf.webpage.url`, `hrdf.meta.canonical_url`, `hrdf.trip.url` |
+| og:site_name | `hrdf.org.name`, `hrdf.site.name` |
+| og:type | `hrdf.meta.og_type`, `hrdf.webpage.og_type` |
+| og:image | `hrdf.webpage.image`, `hrdf.webpage.images`, `hrdf.trip.images`, `hrdf.hero.image_url`, `hrdf.gallery.images`, `hrdf.trip.gallery.images` |
+| product:price:amount | Offer.price from HRDF sources listed above |
+| product:price:currency | Offer.priceCurrency from HRDF sources listed above |
+| product:availability | Offer.availability from HRDF sources listed above |
+
+## Twitter Cards
+
+| Twitter Field | HRDF Source Keys (checked in order) |
+| --- | --- |
+| twitter:card | `hrdf.twitter.card` |
+| twitter:title | `hrdf.webpage.title`, `hrdf.meta.title`, `hrdf.trip.title` |
+| twitter:description | `hrdf.webpage.description`, `hrdf.meta.description`, `hrdf.trip.description` |
+| twitter:image | `hrdf.webpage.image`, `hrdf.webpage.images`, `hrdf.trip.images`, `hrdf.hero.image_url`, `hrdf.gallery.images`, `hrdf.trip.gallery.images` |
+| twitter:site | `hrdf.twitter.site` |
+| twitter:creator | `hrdf.twitter.creator` |
+


### PR DESCRIPTION
## Summary
- remove all WordPress fallbacks from context and schema emitters so JSON-LD nodes only use HRDF data
- rebuild trip/product graph helpers to normalise HRDF offers, aggregate offers, and auxiliary nodes without derived data
- align Open Graph and Twitter tag generation with HRDF payloads and document every schema/meta to HRDF mapping

## Testing
- php -l core/hrdf.php
- php -l core/context.php
- php -l modules/jsonld/org.php
- php -l modules/jsonld/trip.php
- php -l modules/og/loader.php

------
https://chatgpt.com/codex/tasks/task_e_68dd167b4c4c8327b6295f37ac695a21