### PR TITLE
Refactor JSON-LD and OG output to source data from HRDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,32 @@ We follow **semantic versioning**:
 - Debug mode can be enabled in settings to access the debug surface.
 - All metadata is emitted early in `<head>` with no duplicates.
 
+### HRDF Mapping
+
+| SEO Field | HRDF Key |
+|-----------|----------|
+| Organization Name / Site Name | `site.name` |
+| Organization URL | `site.url` |
+| Organization Logo | `site.logo_url` |
+| Organization Legal Name | `site.org.legal_name` |
+| Organization Address | `site.org.address.{street,locality,region,postal,country}` |
+| Organization SameAs Profiles | `site.org.same_as` |
+| Organization Contact Points | `site.org.contact_points` |
+| Open Graph Site Name | `site.og.site_name` |
+| Locale | `site.locale` |
+| Twitter Site / Handle / Creator | `site.twitter.site`, `site.twitter.handle`, `site.twitter.creator` |
+| Trip URL | `trip.url` |
+| Trip Title | `trip.title` |
+| Trip Description | `trip.description` |
+| Trip Images | `trip.images` |
+| Trip Additional Property Values | `trip.additional_property` |
+| Trip Itinerary Steps | `trip.itinerary.steps` |
+| Trip FAQ Entries | `trip.faq` |
+| Trip Vehicles | `trip.vehicles` |
+| Trip Reviews | `trip.reviews` |
+| Trip Aggregate Rating | `trip.aggregateRating` |
+| Trip Offers | `trip.offers` |
+
 ---
 
 ## Roadmap

--- a/TESTING.md
+++ b/TESTING.md
@@ -128,6 +128,11 @@ Rename MU files back to `*.php` so production behavior is unchanged until we shi
 2. Trigger a preview for any page and focus on the **Type** column.
 3. Confirm that entries whose context or type equals `https://schema.org/` now display as **Schema.org** (humanized host) instead of showing a blank label.
 
+## Preview Smoke Tests — HRDF Data
+1. Open **HR SEO → JSON-LD Preview** and load a published Trip. Confirm the preview includes Organization, Product, Itinerary, FAQ, Vehicles, and Review rows populated solely from HRDF values.
+2. In **HR SEO → Open Graph Preview**, load the same Trip. Verify the card shows title, description, URL, image, price, and availability drawn from HRDF (no WordPress fallbacks).
+3. Switch the Open Graph preview to a non-Trip item. Ensure fields only surface when HRDF provides data (blank values remain empty).
+
 ✅ **Phase 0 is complete** when:
 - JSON-LD parity is verified on the three page types.
 - Admin UI & Debug behave correctly.

--- a/core/context.php
+++ b/core/context.php
@@ -12,58 +12,68 @@ if (!defined('ABSPATH')) {
 }
 
 /**
- * Build the canonical SEO context for the current request.
+ * Build the canonical SEO context for the current request using HRDF values.
  *
  * @return array<string, mixed>
  */
 function hr_sa_get_context(): array
 {
-    $post_id   = is_singular() ? (int) get_queried_object_id() : 0;
-    $type      = hr_sa_detect_content_type();
-    $site_name = hr_sa_context_clean_string((string) hr_sa_get_setting('hr_sa_site_name', get_bloginfo('name')));
-    $site_name = $site_name !== '' ? $site_name : hr_sa_context_clean_string((string) get_bloginfo('name'));
-    $locale    = (string) hr_sa_get_setting('hr_sa_locale', get_locale());
-    $twitter   = (string) hr_sa_get_setting('hr_sa_twitter_handle', '');
-    $image     = hr_sa_resolve_context_image_url($post_id > 0 ? $post_id : null);
+    $post_id = is_singular() ? (int) get_queried_object_id() : 0;
+    $type    = hr_sa_detect_content_type();
+    $site    = hr_sa_hrdf_site_payload();
 
     $context = [
-        'url'            => hr_sa_guess_canonical_url(),
         'type'           => $type,
-        'title'          => hr_sa_resolve_context_title($type, $post_id, $site_name),
-        'description'    => hr_sa_resolve_context_description($type, $post_id, $site_name),
-        'country'        => hr_sa_resolve_context_country($type, $post_id),
-        'site_name'      => $site_name,
-        'locale'         => $locale !== '' ? $locale : get_locale(),
-        'twitter_handle' => $twitter,
-        'hero_url'       => $image,
-        'image'          => $image,
+        'url'            => $site['url'] ?? '',
+        'title'          => $site['name'] ?? '',
+        'description'    => '',
+        'country'        => '',
+        'site_name'      => $site['name'] ?? '',
+        'og_site_name'   => $site['og_name'] ?? '',
+        'locale'         => $site['locale'] ?? '',
+        'twitter_handle' => $site['twitter']['handle'] ?? ($site['twitter']['site'] ?? ''),
+        'twitter_site'   => $site['twitter']['site'] ?? '',
+        'twitter_creator'=> $site['twitter']['creator'] ?? '',
+        'hero_url'       => '',
+        'image'          => '',
+        'offers'         => [],
     ];
 
-    return apply_filters('hr_sa_get_context', $context);
-}
+    if ($type === 'trip' && $post_id > 0) {
+        $trip = hr_sa_hrdf_trip_payload($post_id);
 
-/**
- * Guess a canonical URL for the current view.
- */
-function hr_sa_guess_canonical_url(): string
-{
-    if (is_front_page() || is_home()) {
-        return trailingslashit(set_url_scheme(home_url('/'), 'https'));
-    }
-
-    if (is_singular()) {
-        $permalink = get_permalink();
-        if ($permalink) {
-            return trailingslashit(set_url_scheme($permalink, 'https'));
+        if (!empty($trip['url'])) {
+            $context['url'] = $trip['url'];
         }
+        if (!empty($trip['title'])) {
+            $context['title'] = $trip['title'];
+        }
+        if (!empty($trip['description'])) {
+            $context['description'] = $trip['description'];
+        }
+
+        $images = is_array($trip['images']) ? $trip['images'] : [];
+        if ($images) {
+            $primary = (string) reset($images);
+            if ($primary !== '') {
+                $context['image']    = $primary;
+                $context['hero_url'] = $primary;
+            }
+        }
+
+        $context['offers'] = is_array($trip['offers']) ? $trip['offers'] : [];
     }
 
-    $current_url = home_url(add_query_arg([]));
-    if (is_string($current_url) && $current_url !== '') {
-        return set_url_scheme($current_url, 'https');
+    if ($context['hero_url'] === '') {
+        $context['hero_url'] = $context['image'];
     }
 
-    return trailingslashit(set_url_scheme(home_url('/'), 'https'));
+    /**
+     * Filter the assembled SEO context array.
+     *
+     * @param array<string, mixed> $context
+     */
+    return apply_filters('hr_sa_get_context', $context);
 }
 
 /**
@@ -99,64 +109,9 @@ function hr_sa_context_clean_string(string $text): string
 }
 
 /**
- * Condense text and trim to a word boundary.
- */
-function hr_sa_trim_text(string $text, int $limit = 0): string
-{
-    $clean = hr_sa_context_clean_string($text);
-    if ($clean === '') {
-        return '';
-    }
-
-    if ($limit > 0) {
-        $clean = wp_trim_words($clean, $limit, '…');
-    }
-
-    return $clean;
-}
-
-/**
- * Apply template replacements and normalize whitespace.
- *
- * @param array<string, string> $replacements
- */
-function hr_sa_apply_template_replacements(string $template, array $replacements): string
-{
-    if ($template === '') {
-        return '';
-    }
-
-    $result = strtr($template, $replacements);
-    $result = (string) preg_replace('/\{\{[^}]+\}\}/', '', $result);
-
-    return hr_sa_context_clean_string($result);
-}
-
-/**
- * Append a brand suffix to a title if it is not already present.
- */
-function hr_sa_append_brand_suffix(string $title, string $site_name): string
-{
-    $title = hr_sa_context_clean_string($title);
-    $brand = hr_sa_context_clean_string($site_name);
-
-    if ($brand === '') {
-        return $title;
-    }
-
-    if ($title === '') {
-        return $brand;
-    }
-
-    if (stripos($title, $brand) !== false) {
-        return $title;
-    }
-
-    return $title . ' | ' . $brand;
-}
-
-/**
  * Resolve comma-separated country names for a trip.
+ *
+ * Used by AI helpers that still rely on taxonomy data.
  */
 function hr_sa_resolve_trip_countries(int $post_id): string
 {
@@ -169,167 +124,6 @@ function hr_sa_resolve_trip_countries(int $post_id): string
     $names = array_values(array_filter($names, static fn(string $name): bool => $name !== ''));
 
     return $names ? implode(', ', $names) : '';
-}
-
-/**
- * Build the context title using templates and fallbacks.
- */
-function hr_sa_resolve_context_title(string $type, int $post_id, string $site_name): string
-{
-    if ($type === 'home') {
-        return $site_name;
-    }
-
-    if ($type === 'trip' && $post_id > 0) {
-        $template = (string) hr_sa_get_setting('hr_sa_tpl_trip', '{{trip_name}} | Motorcycle Tour in {{country}}');
-        $replacements = [
-            '{{trip_name}}' => hr_sa_context_clean_string(get_the_title($post_id) ?: ''),
-            '{{country}}'   => hr_sa_resolve_trip_countries($post_id),
-            '{{site_name}}' => $site_name,
-        ];
-        $title = hr_sa_apply_template_replacements($template, $replacements);
-        if ($title === '') {
-            $title = $replacements['{{trip_name}}'];
-        }
-
-        return $title !== '' ? $title : $site_name;
-    }
-
-    if ($post_id > 0) {
-        $template = (string) hr_sa_get_setting('hr_sa_tpl_page', '{{page_title}}');
-        $replacements = [
-            '{{page_title}}' => hr_sa_context_clean_string(get_the_title($post_id) ?: ''),
-            '{{site_name}}'  => $site_name,
-        ];
-        $title = hr_sa_apply_template_replacements($template, $replacements);
-        if ($title === '') {
-            $title = $replacements['{{page_title}}'];
-        }
-
-        if (hr_sa_get_setting('hr_sa_tpl_page_brand_suffix')) {
-            $title = hr_sa_append_brand_suffix($title, $site_name);
-        }
-
-        return $title !== '' ? $title : $site_name;
-    }
-
-    return $site_name;
-}
-
-/**
- * Resolve the context description based on content type.
- */
-function hr_sa_resolve_context_description(string $type, int $post_id, string $site_name): string
-{
-    if ($type === 'home') {
-        $tagline = (string) get_bloginfo('description', 'display');
-        $description = hr_sa_trim_text($tagline, 40);
-
-        return $description !== '' ? $description : $site_name;
-    }
-
-    $candidates = [];
-    if ($post_id > 0) {
-        if ($type === 'trip') {
-            if (function_exists('get_field')) {
-                $acf_description = get_field('description', $post_id);
-                if (is_string($acf_description) && $acf_description !== '') {
-                    $candidates[] = $acf_description;
-                }
-            }
-
-            $meta_description = get_post_meta($post_id, 'description', true);
-            if (is_string($meta_description) && $meta_description !== '') {
-                $candidates[] = $meta_description;
-            }
-        }
-
-        $excerpt = (string) get_post_field('post_excerpt', $post_id);
-        if ($excerpt !== '') {
-            $candidates[] = $excerpt;
-        }
-
-        $content = (string) get_post_field('post_content', $post_id);
-        if ($content !== '') {
-            $candidates[] = $content;
-        }
-    }
-
-    foreach ($candidates as $candidate) {
-        $clean = hr_sa_trim_text(strip_shortcodes((string) $candidate), 45);
-        if ($clean !== '') {
-            return $clean;
-        }
-    }
-
-    $fallback = (string) get_bloginfo('description', 'display');
-    $clean = hr_sa_trim_text($fallback, 40);
-
-    return $clean !== '' ? $clean : $site_name;
-}
-
-/**
- * Resolve the country string for the context payload.
- */
-function hr_sa_resolve_context_country(string $type, int $post_id): string
-{
-    if ($type !== 'trip' || $post_id <= 0) {
-        return '';
-    }
-
-    return hr_sa_resolve_trip_countries($post_id);
-}
-
-/**
- * Resolve the preferred image URL for the context.
- */
-function hr_sa_resolve_context_image_url(?int $post_id): ?string
-{
-    $candidates = [];
-
-    if ($post_id) {
-        $meta = get_post_meta($post_id, '_hrih_header_image_url', true);
-        if (is_array($meta) && isset($meta['url'])) {
-            $meta = (string) $meta['url'];
-        }
-        if (is_string($meta) && $meta !== '') {
-            $candidates[] = $meta;
-        }
-    }
-
-    $connector = hr_sa_get_media_help_hero_url();
-    if ($connector) {
-        $candidates[] = $connector;
-    }
-
-    $fallback = (string) hr_sa_get_setting('hr_sa_fallback_image', '');
-    if ($fallback !== '') {
-        $candidates[] = $fallback;
-    }
-
-    $resolved = null;
-    foreach ($candidates as $candidate) {
-        $sanitized = hr_sa_sanitize_context_image_url((string) $candidate);
-        if ($sanitized === null) {
-            continue;
-        }
-
-        $transformed = hr_sa_apply_image_url_replacements($sanitized);
-        if ($transformed !== '') {
-            $resolved = $transformed;
-            break;
-        }
-    }
-
-    /**
-     * Allow the resolved image URL to be filtered.
-     *
-     * @param string|null $resolved
-     * @param int|null    $post_id
-     */
-    $resolved = apply_filters('hr_sa_context_image_url', $resolved, $post_id);
-
-    return $resolved !== '' ? $resolved : null;
 }
 
 /**
@@ -418,15 +212,14 @@ function hr_sa_apply_image_url_replacements(string $url): string
             $updated = substr($updated, 0, strlen($updated) - $suffix_length) . $rules['suffix_replace'];
         }
     } elseif ($rules['suffix_replace'] !== '') {
-        // If no suffix find term is configured, append the replacement directly.
         $updated .= $rules['suffix_replace'];
     }
 
     /**
      * Filter the transformed image URL prior to sanitization.
      *
-     * @param string               $updated
-     * @param string               $original
+     * @param string                $updated
+     * @param string                $original
      * @param array<string, string> $rules
      */
     $updated = (string) apply_filters('hr_sa_image_url_replacement', $updated, $original, $rules);

--- a/core/hrdf.php
+++ b/core/hrdf.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * HR Data Framework integration helpers.
+ *
+ * @package HR_SEO_Assistant
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Retrieve a value from the HR Data Framework using helper accessors when available.
+ *
+ * @param mixed $default
+ * @return mixed
+ */
+function hr_sa_hrdf_get(string $path, ?int $post_id = null, $default = null)
+{
+    $path       = trim($path);
+    $accessor   = 'hr_df_' . str_replace('.', '_', $path);
+    $has_post   = $post_id !== null;
+    $post_id    = $has_post ? (int) $post_id : null;
+    $parameters = $has_post ? [$post_id] : [];
+
+    if (function_exists($accessor)) {
+        return $accessor(...$parameters);
+    }
+
+    if (function_exists('hr_df_get')) {
+        return hr_df_get($path, $has_post ? $post_id : null, $default);
+    }
+
+    return $default;
+}
+
+/**
+ * Convenience wrapper for site-level lookups.
+ *
+ * @param mixed $default
+ * @return mixed
+ */
+function hr_sa_hrdf_site(string $path, $default = null)
+{
+    return hr_sa_hrdf_get('site.' . $path, null, $default);
+}
+
+/**
+ * Convenience wrapper for trip-level lookups.
+ *
+ * @param mixed $default
+ * @return mixed
+ */
+function hr_sa_hrdf_trip(string $path, int $post_id, $default = null)
+{
+    return hr_sa_hrdf_get('trip.' . $path, $post_id, $default);
+}
+
+/**
+ * Normalize arbitrary values into trimmed strings.
+ */
+function hr_sa_hrdf_normalize_text($value): string
+{
+    if (is_array($value) || is_object($value)) {
+        $value = wp_json_encode($value);
+    }
+
+    $text = wp_strip_all_tags((string) $value, true);
+    $text = html_entity_decode($text, ENT_QUOTES, get_bloginfo('charset') ?: 'UTF-8');
+    $text = (string) preg_replace('/\s+/u', ' ', $text);
+
+    return trim($text);
+}
+
+/**
+ * Normalize URL values and coerce to HTTPS when possible.
+ */
+function hr_sa_hrdf_normalize_url($value): string
+{
+    $url = trim((string) $value);
+    if ($url === '') {
+        return '';
+    }
+
+    $sanitized = esc_url_raw($url);
+    if ($sanitized === '') {
+        return '';
+    }
+
+    return set_url_scheme($sanitized, 'https');
+}
+
+/**
+ * Normalize a list of URLs.
+ *
+ * @param mixed $value
+ * @return array<int, string>
+ */
+function hr_sa_hrdf_normalize_url_list($value): array
+{
+    if (!is_array($value)) {
+        return [];
+    }
+
+    $urls = [];
+    foreach ($value as $candidate) {
+        $normalized = hr_sa_hrdf_normalize_url($candidate);
+        if ($normalized !== '') {
+            $urls[] = $normalized;
+        }
+    }
+
+    return array_values(array_unique($urls));
+}
+
+/**
+ * Format a numeric price for schema output.
+ */
+function hr_sa_hrdf_format_price(float $value): string
+{
+    return number_format($value, 2, '.', '');
+}
+
+/**
+ * Cast arbitrary values to array.
+ *
+ * @param mixed $value
+ * @return array<int, mixed>
+ */
+function hr_sa_hrdf_to_array($value): array
+{
+    return is_array($value) ? $value : [];
+}
+
+/**
+ * Retrieve and cache site-level HRDF payload.
+ *
+ * @return array<string, mixed>
+ */
+function hr_sa_hrdf_site_payload(): array
+{
+    static $cache = null;
+    if (is_array($cache)) {
+        return $cache;
+    }
+
+    $name      = hr_sa_hrdf_normalize_text(hr_sa_hrdf_site('name', ''));
+    $url       = hr_sa_hrdf_normalize_url(hr_sa_hrdf_site('url', ''));
+    $logo_url  = hr_sa_hrdf_normalize_url(hr_sa_hrdf_site('logo_url', ''));
+    $locale    = hr_sa_hrdf_normalize_text(hr_sa_hrdf_site('locale', ''));
+    $og_name   = hr_sa_hrdf_normalize_text(hr_sa_hrdf_site('og.site_name', ''));
+    $same_as   = [];
+    $raw_same  = hr_sa_hrdf_to_array(hr_sa_hrdf_site('org.same_as', []));
+    foreach ($raw_same as $entry) {
+        $candidate = hr_sa_hrdf_normalize_url($entry);
+        if ($candidate !== '') {
+            $same_as[] = $candidate;
+        }
+    }
+
+    $contact_points = [];
+    $raw_points     = hr_sa_hrdf_to_array(hr_sa_hrdf_site('org.contact_points', []));
+    foreach ($raw_points as $row) {
+        if (!is_array($row)) {
+            continue;
+        }
+
+        $contact_point = ['@type' => 'ContactPoint'];
+        $contact_type  = hr_sa_hrdf_normalize_text($row['contactType'] ?? '');
+        $telephone     = hr_sa_hrdf_normalize_text($row['telephone'] ?? '');
+        $email         = sanitize_email((string) ($row['email'] ?? ''));
+        $area_served   = hr_sa_hrdf_normalize_text($row['areaServed'] ?? '');
+        $language      = hr_sa_hrdf_normalize_text($row['availableLanguage'] ?? '');
+
+        if ($contact_type !== '') {
+            $contact_point['contactType'] = $contact_type;
+        }
+        if ($telephone !== '') {
+            $contact_point['telephone'] = preg_replace('/\s+/u', '', $telephone) ?: $telephone;
+        }
+        if ($email !== '') {
+            $contact_point['email'] = $email;
+        }
+        if ($area_served !== '') {
+            $contact_point['areaServed'] = $area_served;
+        }
+        if ($language !== '') {
+            $contact_point['availableLanguage'] = $language;
+        }
+
+        if (count($contact_point) > 1) {
+            $contact_points[] = $contact_point;
+        }
+    }
+
+    $address = [];
+    $address_keys = [
+        'streetAddress'   => 'org.address.street',
+        'addressLocality' => 'org.address.locality',
+        'addressRegion'   => 'org.address.region',
+        'postalCode'      => 'org.address.postal',
+        'addressCountry'  => 'org.address.country',
+    ];
+    foreach ($address_keys as $field => $path) {
+        $value = hr_sa_hrdf_normalize_text(hr_sa_hrdf_site($path, ''));
+        if ($value !== '') {
+            $address[$field] = $value;
+        }
+    }
+
+    $twitter_site    = hr_sa_hrdf_normalize_text(hr_sa_hrdf_site('twitter.site', ''));
+    $twitter_creator = hr_sa_hrdf_normalize_text(hr_sa_hrdf_site('twitter.creator', ''));
+    $twitter_handle  = hr_sa_hrdf_normalize_text(hr_sa_hrdf_site('twitter.handle', ''));
+
+    $org_payload = [
+        'name'       => $name,
+        'legal_name' => hr_sa_hrdf_normalize_text(hr_sa_hrdf_site('org.legal_name', '')),
+        'address'    => $address,
+        'same_as'    => $same_as,
+        'contact'    => $contact_points,
+    ];
+
+    $cache = [
+        'name'      => $name,
+        'url'       => $url,
+        'logo_url'  => $logo_url,
+        'locale'    => $locale,
+        'og_name'   => $og_name,
+        'twitter'   => array_filter(
+            [
+                'site'    => $twitter_site,
+                'creator' => $twitter_creator,
+                'handle'  => $twitter_handle,
+            ],
+            static fn(string $value): bool => $value !== ''
+        ),
+        'org'       => $org_payload,
+    ];
+
+    return $cache;
+}
+
+/**
+ * Retrieve and cache the full HRDF payload for a trip.
+ *
+ * @return array<string, mixed>
+ */
+function hr_sa_hrdf_trip_payload(int $post_id): array
+{
+    static $cache = [];
+    if (isset($cache[$post_id])) {
+        return $cache[$post_id];
+    }
+
+    $aggregate = hr_sa_hrdf_trip('aggregateRating', $post_id, null);
+
+    $payload = [
+        'url'                 => hr_sa_hrdf_normalize_url(hr_sa_hrdf_trip('url', $post_id, '')),
+        'title'               => hr_sa_hrdf_normalize_text(hr_sa_hrdf_trip('title', $post_id, '')),
+        'description'         => hr_sa_hrdf_normalize_text(hr_sa_hrdf_trip('description', $post_id, '')),
+        'images'              => hr_sa_hrdf_normalize_url_list(hr_sa_hrdf_trip('images', $post_id, [])),
+        'additional_property' => hr_sa_hrdf_to_array(hr_sa_hrdf_trip('additional_property', $post_id, [])),
+        'itinerary'           => hr_sa_hrdf_to_array(hr_sa_hrdf_trip('itinerary.steps', $post_id, [])),
+        'faq'                 => hr_sa_hrdf_to_array(hr_sa_hrdf_trip('faq', $post_id, [])),
+        'vehicles'            => hr_sa_hrdf_to_array(hr_sa_hrdf_trip('vehicles', $post_id, [])),
+        'reviews'             => hr_sa_hrdf_to_array(hr_sa_hrdf_trip('reviews', $post_id, [])),
+        'aggregate_rating'    => is_array($aggregate) ? $aggregate : null,
+        'offers'              => hr_sa_hrdf_to_array(hr_sa_hrdf_trip('offers', $post_id, [])),
+    ];
+
+    return $cache[$post_id] = $payload;
+}

--- a/hr-seo-assistant.php
+++ b/hr-seo-assistant.php
@@ -24,6 +24,7 @@ define('HR_SA_PLUGIN_URL', plugin_dir_url(__FILE__));
 
 require_once HR_SA_PLUGIN_DIR . 'core/settings.php';
 require_once HR_SA_PLUGIN_DIR . 'core/feature-flags.php';
+require_once HR_SA_PLUGIN_DIR . 'core/hrdf.php';
 require_once HR_SA_PLUGIN_DIR . 'core/context.php';
 require_once HR_SA_PLUGIN_DIR . 'core/ai.php';
 require_once HR_SA_PLUGIN_DIR . 'core/compat.php';

--- a/modules/jsonld/itinerary.php
+++ b/modules/jsonld/itinerary.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Itinerary JSON-LD helpers.
+ * Itinerary JSON-LD helpers driven by HRDF.
  *
  * @package HR_SEO_Assistant
  */
@@ -14,108 +14,60 @@ if (!defined('ABSPATH')) {
 /**
  * Build an ItemList node representing the itinerary.
  *
- * @param int    $trip_id
- * @param string $product_id
- * @param array<int> $country_term_ids
- *
+ * @param array<int, mixed> $steps
  * @return array{0: array<string, mixed>|null, 1: array<string, string>|null}
  */
-function hr_sa_trip_itinerary_node(int $trip_id, string $product_id, array $country_term_ids): array
+function hr_sa_trip_itinerary_node_from_hrdf(array $steps, string $trip_url, string $product_id): array
 {
-    $posts = get_posts([
-        'post_type'      => 'itinerary',
-        'posts_per_page' => -1,
-        'tax_query'      => [
-            [
-                'taxonomy' => 'country',
-                'field'    => 'term_id',
-                'terms'    => $country_term_ids,
-            ],
-        ],
-        'post_status'    => 'publish',
-        'orderby'        => 'menu_order',
-        'order'          => 'ASC',
-    ]);
-
-    if (!$posts) {
+    if (!$steps) {
         return [null, null];
     }
 
-    $elements = [];
+    $items    = [];
     $position = 1;
 
-    foreach ($posts as $itinerary) {
-        $title = hr_sa_trip_clean_text(get_the_title($itinerary->ID));
-        if ($title === '') {
+    foreach ($steps as $step) {
+        if (count($items) >= 8) {
+            break;
+        }
+
+        if (is_array($step)) {
+            $label = hr_sa_hrdf_normalize_text($step['name'] ?? ($step['title'] ?? ''));
+        } else {
+            $label = hr_sa_hrdf_normalize_text($step);
+        }
+
+        if ($label === '') {
             continue;
         }
 
-        $summary = '';
-        $labels  = [];
-
-        $steps = function_exists('get_field') ? get_field('itinerary_steps', $itinerary->ID) : get_post_meta($itinerary->ID, 'itinerary_steps', true);
-        if (is_array($steps) && $steps) {
-            foreach ($steps as $row) {
-                $name = '';
-                if (is_array($row)) {
-                    $name = $row['title'] ?? ($row['name'] ?? '');
-                } else {
-                    $name = (string) $row;
-                }
-
-                $name = hr_sa_trip_clean_text($name);
-                if ($name !== '') {
-                    $labels[] = $name;
-                }
-
-                if (count($labels) >= 8) {
-                    break;
-                }
-            }
-            $summary = implode('; ', $labels);
-        } else {
-            $content = apply_filters('the_content', $itinerary->post_content);
-            if ($content && preg_match_all('/<(h2|h3)[^>]*>(.*?)<\/\\1>/i', $content, $matches)) {
-                foreach ($matches[2] as $heading) {
-                    $heading = hr_sa_trip_clean_text($heading);
-                    if ($heading) {
-                        $labels[] = $heading;
-                    }
-                    if (count($labels) >= 8) {
-                        break;
-                    }
-                }
-                $summary = implode('; ', $labels);
-            } else {
-                $summary = hr_sa_trip_clean_text($itinerary->post_content, 50);
-            }
-        }
-
-        $item = [
+        $items[] = [
             '@type'    => 'ListItem',
             'position' => $position++,
-            'name'     => $title,
+            'name'     => $label,
         ];
-
-        if ($summary !== '') {
-            $item['description'] = $summary;
-        }
-
-        $elements[] = $item;
     }
 
-    if (!$elements) {
+    if (!$items) {
         return [null, null];
     }
 
-    $trip_url     = get_permalink($trip_id);
-    $itinerary_id = $trip_url ? ($trip_url . '#itinerary') : ($product_id . '-itinerary');
-    $node         = [
+    $list_id = '';
+    if ($trip_url !== '') {
+        $list_id = rtrim($trip_url, '/') . '#itinerary';
+    } elseif ($product_id !== '') {
+        $list_id = $product_id . '-itinerary';
+    }
+
+    $node = [
         '@type'           => 'ItemList',
-        '@id'             => $itinerary_id,
-        'name'            => 'Itinerary',
-        'itemListElement' => $elements,
+        'name'            => __('Itinerary', HR_SA_TEXT_DOMAIN),
+        'itemListElement' => $items,
     ];
 
-    return [$node, ['@id' => $itinerary_id]];
+    if ($list_id !== '') {
+        $node['@id'] = $list_id;
+    }
+
+    return [$node, $list_id !== '' ? ['@id' => $list_id] : null];
 }

--- a/modules/jsonld/vehicles.php
+++ b/modules/jsonld/vehicles.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Vehicle helper nodes for JSON-LD.
+ * Vehicle helper nodes for JSON-LD sourced from HRDF.
  *
  * @package HR_SEO_Assistant
  */
@@ -12,233 +12,75 @@ if (!defined('ABSPATH')) {
 }
 
 /**
- * Collect Vehicle nodes for bikes associated with country terms.
+ * Collect Vehicle nodes for bikes associated with the trip HRDF payload.
  *
- * @return array{0: array<int, array<string, mixed>>, 1: array<int, string>, 2: array<int, array<string, string>>}
+ * @param array<int, mixed> $vehicles
+ * @return array{0: array<int, array<string, mixed>>, 1: array<int, array<string, string>>}
  */
-function hr_sa_trip_bike_nodes(int $trip_id, array $country_term_ids): array
+function hr_sa_trip_vehicle_nodes_from_hrdf(array $vehicles, string $trip_url, string $product_id): array
 {
     $nodes = [];
-    $names = [];
-    $about = [];
+    $refs  = [];
 
-    $bikes = get_posts([
-        'post_type'      => 'bike',
-        'posts_per_page' => 12,
-        'tax_query'      => [
-            [
-                'taxonomy' => 'country',
-                'field'    => 'term_id',
-                'terms'    => $country_term_ids,
-            ],
-        ],
-        'post_status'    => 'publish',
-        'orderby'        => 'menu_order',
-        'order'          => 'ASC',
-    ]);
-
-    $trip_url = get_permalink($trip_id);
-
-    foreach ($bikes as $bike) {
-        $url     = get_permalink($bike->ID);
-        $bike_id = $url ? ($url . '#bike') : ($trip_url . '#bike-' . $bike->ID);
-        $name    = get_the_title($bike->ID);
-
-        $image = null;
-        if (function_exists('get_field')) {
-            $field = get_field('photo_bike', $bike->ID);
-            if (is_array($field)) {
-                if (!empty($field['url'])) {
-                    $image = $field['url'];
-                } elseif (!empty($field['ID'])) {
-                    $image = wp_get_attachment_image_url((int) $field['ID'], 'full');
-                }
-            } elseif (is_numeric($field)) {
-                $image = wp_get_attachment_image_url((int) $field, 'full');
-            } elseif (is_string($field) && filter_var($field, FILTER_VALIDATE_URL)) {
-                $image = $field;
-            }
+    foreach ($vehicles as $index => $vehicle) {
+        if (!is_array($vehicle)) {
+            continue;
         }
 
-        if (!$image) {
-            $image = get_the_post_thumbnail_url($bike->ID, 'full');
+        $name = isset($vehicle['name']) ? hr_sa_hrdf_normalize_text($vehicle['name']) : '';
+        if ($name === '') {
+            continue;
         }
 
-        $node = array_filter([
+        $vehicle_id = '';
+        if ($trip_url !== '') {
+            $vehicle_id = rtrim($trip_url, '/') . '#vehicle-' . ((int) $index + 1);
+        } elseif ($product_id !== '') {
+            $vehicle_id = $product_id . '-vehicle-' . ((int) $index + 1);
+        }
+
+        $node = [
             '@type' => 'Vehicle',
-            '@id'   => $bike_id,
-            'name'  => $name ?: null,
-            'image' => $image ?: null,
-            'url'   => $url ?: null,
-        ], static fn($value) => $value !== null && $value !== '');
-
-        $nodes[] = $node;
-        if ($name) {
-            $names[] = $name;
-        }
-        $about[] = ['@id' => $bike_id];
-    }
-
-    return [$nodes, $names, $about];
-}
-
-/**
- * Return map of normalized bike name => Offer node array for schema usage.
- *
- * @param string $trip_url
- * @return array<string, array<string, string>>
- */
-function hr_sa_wte_build_vehicle_offer_map(int $trip_id, string $trip_url): array
-{
-    $trip_id = (int) $trip_id;
-    if ($trip_id <= 0) {
-        return [];
-    }
-
-    $pairs = hr_sa_wte_get_rental_pairs($trip_id);
-    if (empty($pairs)) {
-        return [];
-    }
-
-    $currency  = 'USD';
-    $base_url  = '';
-    $candidate = is_string($trip_url) && $trip_url !== '' ? esc_url_raw($trip_url) : get_permalink($trip_id);
-    if (is_string($candidate) && $candidate !== '') {
-        $base_url = rtrim($candidate, '/');
-    }
-
-    $map = [];
-
-    foreach ($pairs as $pair) {
-        if (!is_array($pair)) {
-            continue;
-        }
-
-        $name = isset($pair['name']) ? sanitize_text_field((string) $pair['name']) : '';
-        if ($name === '') {
-            continue;
-        }
-
-        $normalized  = hr_sa_norm_bike_name($name);
-        $price       = isset($pair['price']) && is_numeric($pair['price']) ? (string) (0 + $pair['price']) : '0';
-        $description = isset($pair['description']) && $pair['description'] !== ''
-            ? sanitize_text_field((string) $pair['description'])
-            : null;
-
-        $map[$normalized] = array_filter(
-            [
-                '@type'         => 'Offer',
-                'price'         => $price,
-                'priceCurrency' => $currency,
-                'availability'  => 'https://schema.org/InStock',
-                'url'           => ($base_url !== '' ? $base_url : rtrim((string) get_permalink($trip_id), '/')) . '#intro',
-                'description'   => $description,
-            ],
-            static fn($value) => $value !== null
-        );
-    }
-
-    return $map;
-}
-
-/**
- * Normalize bike names for consistent keys.
- */
-function hr_sa_norm_bike_name(string $value): string
-{
-    $value = strtolower($value);
-    $value = preg_replace('/[–—−]+/u', '-', $value) ?? '';
-    $value = preg_replace('/\b(\d+)\s*mt\b/u', '$1mt', $value) ?? '';
-    $value = preg_replace('/[^\p{L}\p{N}]+/u', ' ', $value) ?? '';
-    $value = trim(preg_replace('/\s+/', ' ', $value) ?? '');
-
-    return $value;
-}
-
-/**
- * Extract rental bike option pairs (name, price, description) from WTE meta.
- *
- * @return array<int, array{name: string, price: float, description: string}>
- */
-function hr_sa_wte_get_rental_pairs(int $trip_id): array
-{
-    $pairs   = [];
-    $setting = get_post_meta($trip_id, 'wp_travel_engine_setting', true);
-    if (!is_array($setting)) {
-        return $pairs;
-    }
-
-    $services = $setting['trip_extra_services'] ?? $setting['extra_services'] ?? [];
-    if (!is_array($services)) {
-        $services = [];
-    }
-
-    $chosen = get_post_meta($trip_id, 'wte_services_ids', true);
-    if (is_array($chosen)) {
-        $chosen = reset($chosen);
-    }
-    if (is_object($chosen) && isset($chosen->ID)) {
-        $chosen = $chosen->ID;
-    }
-
-    $target = null;
-    foreach ($services as $service) {
-        if (!is_array($service)) {
-            continue;
-        }
-
-        $id = $service['id'] ?? $service['service_id'] ?? null;
-        if ($chosen && $id && (string) $id === (string) $chosen) {
-            $target = $service;
-            break;
-        }
-    }
-
-    if (!$target) {
-        foreach ($services as $service) {
-            if (!is_array($service)) {
-                continue;
-            }
-
-            $label = strtolower((string) ($service['label'] ?? $service['service_label'] ?? ''));
-            if ($label !== '' && str_contains($label, 'rental bike')) {
-                $target = $service;
-                break;
-            }
-        }
-    }
-
-    if (!$target) {
-        return $pairs;
-    }
-
-    $options = $target['options'] ?? $target['service_options'] ?? [];
-    $prices  = $target['prices'] ?? $target['service_prices'] ?? [];
-    $descs   = $target['descriptions'] ?? $target['service_descriptions'] ?? [];
-    if (empty($options) && isset($target['data']) && is_array($target['data'])) {
-        $data    = $target['data'];
-        $options = $data['options'] ?? $options;
-        $prices  = $data['prices'] ?? $prices;
-        $descs   = $data['descriptions'] ?? $descs;
-    }
-
-    $count = max(count((array) $options), count((array) $prices), count((array) $descs));
-
-    for ($i = 0; $i < $count; $i++) {
-        $name  = is_array($options) ? sanitize_text_field((string) ($options[$i] ?? '')) : '';
-        $price = is_array($prices) ? $prices[$i] ?? '' : '';
-        $desc  = is_array($descs) ? sanitize_text_field((string) ($descs[$i] ?? '')) : '';
-
-        if ($name === '') {
-            continue;
-        }
-
-        $pairs[] = [
-            'name'        => $name,
-            'price'       => is_numeric($price) ? (float) $price : 0.0,
-            'description' => $desc,
+            'name'  => $name,
         ];
+
+        if ($vehicle_id !== '') {
+            $node['@id'] = $vehicle_id;
+            $refs[]      = ['@id' => $vehicle_id];
+        }
+
+        $description = isset($vehicle['description']) ? hr_sa_hrdf_normalize_text($vehicle['description']) : '';
+        if ($description !== '') {
+            $node['description'] = $description;
+        }
+
+        $image = isset($vehicle['image']) ? hr_sa_hrdf_normalize_url($vehicle['image']) : '';
+        if ($image !== '') {
+            $node['image'] = $image;
+        }
+
+        $offer_nodes = [];
+        if (!empty($vehicle['offers']) && is_array($vehicle['offers'])) {
+            foreach ($vehicle['offers'] as $offer_index => $offer) {
+                if (!is_array($offer)) {
+                    continue;
+                }
+
+                $normalized = hr_sa_trip_normalize_offer($offer, $vehicle_id ?: $product_id, $trip_url, (int) $offer_index);
+                if ($normalized === null) {
+                    continue;
+                }
+
+                $offer_nodes[] = $normalized['node'];
+            }
+        }
+
+        if ($offer_nodes) {
+            $node['offers'] = $offer_nodes;
+        }
+
+        $nodes[] = hr_sa_trip_filter_schema_array($node);
     }
 
-    return $pairs;
+    return [$nodes, $refs];
 }


### PR DESCRIPTION
## Summary
- add an HRDF integration helper and rewrite the shared SEO context to read site/trip values from HRDF only
- refactor all JSON-LD emitters (organization, trip, itinerary, FAQ, vehicles, reviews, offers) to consume HRDF payloads and emit fail-soft nodes
- update Open Graph/Twitter emitters and previews to surface HRDF-sourced titles, descriptions, prices, availability, and document the SEO→HRDF mapping with new smoke tests

## Testing
- php -l core/hrdf.php
- php -l core/context.php
- php -l modules/jsonld/trip.php
- php -l modules/jsonld/itinerary.php
- php -l modules/jsonld/faq.php
- php -l modules/jsonld/vehicles.php
- php -l modules/jsonld/loader.php
- php -l modules/og/loader.php

------
https://chatgpt.com/codex/tasks/task_e_68df5ef362f0832790686eafd6a4e699