### PR TITLE
Consume batched HRDF trip payload

### DIFF
--- a/core/hrdf.php
+++ b/core/hrdf.php
@@ -59,6 +59,44 @@ function hr_sa_hrdf_trip(string $path, int $post_id, $default = null)
 }
 
 /**
+ * Normalize arbitrary structures into plain arrays.
+ *
+ * @param mixed $value
+ * @return array<mixed>
+ */
+function hr_sa_hrdf_force_array($value): array
+{
+    if (is_array($value)) {
+        return $value;
+    }
+
+    if (is_object($value)) {
+        return get_object_vars($value);
+    }
+
+    return [];
+}
+
+/**
+ * Select the first available value from a list of keys within a source array.
+ *
+ * @param array<string, mixed> $source
+ * @param array<int, string>   $keys
+ * @param mixed                $default
+ * @return mixed
+ */
+function hr_sa_hrdf_pick(array $source, array $keys, $default = null)
+{
+    foreach ($keys as $key) {
+        if (array_key_exists($key, $source)) {
+            return $source[$key];
+        }
+    }
+
+    return $default;
+}
+
+/**
  * Normalize arbitrary values into trimmed strings.
  */
 function hr_sa_hrdf_normalize_text($value): string
@@ -139,20 +177,53 @@ function hr_sa_hrdf_to_array($value): array
  *
  * @return array<string, mixed>
  */
-function hr_sa_hrdf_site_payload(): array
+function hr_sa_hrdf_site_payload(?int $post_id = null): array
 {
-    static $cache = null;
-    if (is_array($cache)) {
-        return $cache;
+    if ($post_id === null && is_singular('trip')) {
+        $post_id = (int) get_queried_object_id();
     }
 
-    $name      = hr_sa_hrdf_normalize_text(hr_sa_hrdf_site('name', ''));
-    $url       = hr_sa_hrdf_normalize_url(hr_sa_hrdf_site('url', ''));
-    $logo_url  = hr_sa_hrdf_normalize_url(hr_sa_hrdf_site('logo_url', ''));
-    $locale    = hr_sa_hrdf_normalize_text(hr_sa_hrdf_site('locale', ''));
-    $og_name   = hr_sa_hrdf_normalize_text(hr_sa_hrdf_site('og.site_name', ''));
-    $same_as   = [];
-    $raw_same  = hr_sa_hrdf_to_array(hr_sa_hrdf_site('org.same_as', []));
+    static $cache = [];
+    $key = $post_id ?? 0;
+    if (isset($cache[$key])) {
+        return $cache[$key];
+    }
+
+    if ($post_id === null || $post_id <= 0) {
+        return $cache[$key] = [];
+    }
+
+    $sections     = hr_sa_hrdf_trip_schema_sections($post_id);
+    $site_section = hr_sa_hrdf_force_array($sections['site'] ?? []);
+    $org_section  = hr_sa_hrdf_force_array($sections['organization'] ?? []);
+    $og_section   = hr_sa_hrdf_force_array($sections['og'] ?? []);
+    $twitter      = hr_sa_hrdf_force_array($sections['twitter'] ?? []);
+
+    $name     = hr_sa_hrdf_normalize_text((string) ($site_section['name'] ?? ''));
+    $url      = hr_sa_hrdf_normalize_url($site_section['url'] ?? '');
+    $logo     = hr_sa_hrdf_normalize_url((string) hr_sa_hrdf_pick($site_section, ['logo_url', 'logo'], ''));
+    $locale   = hr_sa_hrdf_normalize_text((string) ($site_section['locale'] ?? ''));
+    $og_name  = hr_sa_hrdf_normalize_text((string) hr_sa_hrdf_pick($og_section, ['site_name'], $site_section['og_site_name'] ?? ''));
+
+    $address_raw = hr_sa_hrdf_force_array(hr_sa_hrdf_pick($org_section, ['address'], []));
+    $address     = [];
+    foreach (
+        [
+            'streetAddress'   => ['streetAddress', 'street'],
+            'addressLocality' => ['addressLocality', 'locality'],
+            'addressRegion'   => ['addressRegion', 'region'],
+            'postalCode'      => ['postalCode', 'postal'],
+            'addressCountry'  => ['addressCountry', 'country'],
+        ] as $field => $candidates
+    ) {
+        $value = hr_sa_hrdf_normalize_text((string) hr_sa_hrdf_pick($address_raw, $candidates, ''));
+        if ($value !== '') {
+            $address[$field] = $value;
+        }
+    }
+
+    $same_as = [];
+    $raw_same = hr_sa_hrdf_force_array(hr_sa_hrdf_pick($org_section, ['same_as', 'sameAs'], []));
     foreach ($raw_same as $entry) {
         $candidate = hr_sa_hrdf_normalize_url($entry);
         if ($candidate !== '') {
@@ -161,18 +232,19 @@ function hr_sa_hrdf_site_payload(): array
     }
 
     $contact_points = [];
-    $raw_points     = hr_sa_hrdf_to_array(hr_sa_hrdf_site('org.contact_points', []));
+    $raw_points     = hr_sa_hrdf_force_array(hr_sa_hrdf_pick($org_section, ['contact_points', 'contactPoint'], []));
     foreach ($raw_points as $row) {
-        if (!is_array($row)) {
+        if (!is_array($row) && !is_object($row)) {
             continue;
         }
 
+        $row           = hr_sa_hrdf_force_array($row);
         $contact_point = ['@type' => 'ContactPoint'];
-        $contact_type  = hr_sa_hrdf_normalize_text($row['contactType'] ?? '');
-        $telephone     = hr_sa_hrdf_normalize_text($row['telephone'] ?? '');
-        $email         = sanitize_email((string) ($row['email'] ?? ''));
-        $area_served   = hr_sa_hrdf_normalize_text($row['areaServed'] ?? '');
-        $language      = hr_sa_hrdf_normalize_text($row['availableLanguage'] ?? '');
+        $contact_type  = hr_sa_hrdf_normalize_text((string) hr_sa_hrdf_pick($row, ['contactType', 'type'], ''));
+        $telephone     = hr_sa_hrdf_normalize_text((string) hr_sa_hrdf_pick($row, ['telephone', 'phone'], ''));
+        $email         = sanitize_email((string) hr_sa_hrdf_pick($row, ['email'], ''));
+        $area_served   = hr_sa_hrdf_normalize_text((string) hr_sa_hrdf_pick($row, ['areaServed'], ''));
+        $language      = hr_sa_hrdf_normalize_text((string) hr_sa_hrdf_pick($row, ['availableLanguage', 'language'], ''));
 
         if ($contact_type !== '') {
             $contact_point['contactType'] = $contact_type;
@@ -195,51 +267,125 @@ function hr_sa_hrdf_site_payload(): array
         }
     }
 
-    $address = [];
-    $address_keys = [
-        'streetAddress'   => 'org.address.street',
-        'addressLocality' => 'org.address.locality',
-        'addressRegion'   => 'org.address.region',
-        'postalCode'      => 'org.address.postal',
-        'addressCountry'  => 'org.address.country',
-    ];
-    foreach ($address_keys as $field => $path) {
-        $value = hr_sa_hrdf_normalize_text(hr_sa_hrdf_site($path, ''));
-        if ($value !== '') {
-            $address[$field] = $value;
-        }
-    }
-
-    $twitter_site    = hr_sa_hrdf_normalize_text(hr_sa_hrdf_site('twitter.site', ''));
-    $twitter_creator = hr_sa_hrdf_normalize_text(hr_sa_hrdf_site('twitter.creator', ''));
-    $twitter_handle  = hr_sa_hrdf_normalize_text(hr_sa_hrdf_site('twitter.handle', ''));
+    $twitter_payload = array_filter(
+        [
+            'site'    => hr_sa_hrdf_normalize_text((string) hr_sa_hrdf_pick($twitter, ['site', 'site_handle'], '')),
+            'creator' => hr_sa_hrdf_normalize_text((string) hr_sa_hrdf_pick($twitter, ['creator'], '')),
+            'handle'  => hr_sa_hrdf_normalize_text((string) hr_sa_hrdf_pick($twitter, ['handle'], '')),
+        ],
+        static fn(string $value): bool => $value !== ''
+    );
 
     $org_payload = [
-        'name'       => $name,
-        'legal_name' => hr_sa_hrdf_normalize_text(hr_sa_hrdf_site('org.legal_name', '')),
+        'name'       => hr_sa_hrdf_normalize_text((string) hr_sa_hrdf_pick($org_section, ['name'], '')),
+        'legal_name' => hr_sa_hrdf_normalize_text((string) hr_sa_hrdf_pick($org_section, ['legal_name', 'legalName'], '')),
         'address'    => $address,
         'same_as'    => $same_as,
         'contact'    => $contact_points,
     ];
 
-    $cache = [
-        'name'      => $name,
-        'url'       => $url,
-        'logo_url'  => $logo_url,
-        'locale'    => $locale,
-        'og_name'   => $og_name,
-        'twitter'   => array_filter(
-            [
-                'site'    => $twitter_site,
-                'creator' => $twitter_creator,
-                'handle'  => $twitter_handle,
-            ],
-            static fn(string $value): bool => $value !== ''
-        ),
-        'org'       => $org_payload,
+    foreach ($org_payload as $field => $value) {
+        if (is_array($value)) {
+            if ($value === []) {
+                unset($org_payload[$field]);
+            }
+            continue;
+        }
+
+        if ($value === '') {
+            unset($org_payload[$field]);
+        }
+    }
+
+    $payload = [
+        'name'     => $name,
+        'url'      => $url,
+        'logo_url' => $logo,
+        'locale'   => $locale,
+        'og_name'  => $og_name,
+        'twitter'  => is_array($twitter_payload) ? $twitter_payload : [],
+        'org'      => $org_payload,
     ];
 
-    return $cache;
+    foreach ($payload as $field => $value) {
+        if (in_array($field, ['twitter', 'org'], true)) {
+            $payload[$field] = is_array($value) ? $value : [];
+            continue;
+        }
+
+        if (is_array($value) && $value === []) {
+            unset($payload[$field]);
+            continue;
+        }
+
+        if (is_string($value) && $value === '') {
+            unset($payload[$field]);
+        }
+    }
+
+    return $cache[$key] = $payload;
+}
+
+/**
+ * Retrieve the batched HRDF payload for a trip request.
+ *
+ * @return array<string, mixed>
+ */
+function hr_sa_hrdf_trip_schema_payload(int $post_id): array
+{
+    static $cache = [];
+    if (isset($cache[$post_id])) {
+        return $cache[$post_id];
+    }
+
+    if (!function_exists('hrdf_trip_schema_payload')) {
+        return $cache[$post_id] = [];
+    }
+
+    $payload = hrdf_trip_schema_payload($post_id);
+    if (!is_array($payload)) {
+        return $cache[$post_id] = [];
+    }
+
+    return $cache[$post_id] = $payload;
+}
+
+/**
+ * Extract normalized sections from the batched trip payload.
+ *
+ * @return array{
+ *     site: array<mixed>,
+ *     organization: array<mixed>,
+ *     webpage: array<mixed>,
+ *     trip: array<mixed>,
+ *     product: array<mixed>,
+ *     og: array<mixed>,
+ *     twitter: array<mixed>
+ * }
+ */
+function hr_sa_hrdf_trip_schema_sections(int $post_id): array
+{
+    static $cache = [];
+    if (isset($cache[$post_id])) {
+        return $cache[$post_id];
+    }
+
+    $payload  = hr_sa_hrdf_trip_schema_payload($post_id);
+    $sections = [
+        'site'         => [],
+        'organization' => [],
+        'webpage'      => [],
+        'trip'         => [],
+        'product'      => [],
+        'og'           => [],
+        'twitter'      => [],
+    ];
+
+    foreach (array_keys($sections) as $key) {
+        $sections[$key] = hr_sa_hrdf_force_array($payload[$key] ?? []);
+    }
+
+    return $cache[$post_id] = $sections;
 }
 
 /**
@@ -254,20 +400,26 @@ function hr_sa_hrdf_trip_payload(int $post_id): array
         return $cache[$post_id];
     }
 
-    $aggregate = hr_sa_hrdf_trip('aggregateRating', $post_id, null);
+    $sections = hr_sa_hrdf_trip_schema_sections($post_id);
+    $trip     = hr_sa_hrdf_force_array($sections['trip'] ?? []);
+
+    $aggregate = hr_sa_hrdf_force_array(hr_sa_hrdf_pick($trip, ['aggregate_rating', 'aggregateRating'], []));
 
     $payload = [
-        'url'                 => hr_sa_hrdf_normalize_url(hr_sa_hrdf_trip('url', $post_id, '')),
-        'title'               => hr_sa_hrdf_normalize_text(hr_sa_hrdf_trip('title', $post_id, '')),
-        'description'         => hr_sa_hrdf_normalize_text(hr_sa_hrdf_trip('description', $post_id, '')),
-        'images'              => hr_sa_hrdf_normalize_url_list(hr_sa_hrdf_trip('images', $post_id, [])),
-        'additional_property' => hr_sa_hrdf_to_array(hr_sa_hrdf_trip('additional_property', $post_id, [])),
-        'itinerary'           => hr_sa_hrdf_to_array(hr_sa_hrdf_trip('itinerary.steps', $post_id, [])),
-        'faq'                 => hr_sa_hrdf_to_array(hr_sa_hrdf_trip('faq', $post_id, [])),
-        'vehicles'            => hr_sa_hrdf_to_array(hr_sa_hrdf_trip('vehicles', $post_id, [])),
-        'reviews'             => hr_sa_hrdf_to_array(hr_sa_hrdf_trip('reviews', $post_id, [])),
-        'aggregate_rating'    => is_array($aggregate) ? $aggregate : null,
-        'offers'              => hr_sa_hrdf_to_array(hr_sa_hrdf_trip('offers', $post_id, [])),
+        'url'                 => hr_sa_hrdf_normalize_url((string) hr_sa_hrdf_pick($trip, ['url'], '')),
+        'title'               => hr_sa_hrdf_normalize_text((string) hr_sa_hrdf_pick($trip, ['title', 'name'], '')),
+        'description'         => hr_sa_hrdf_normalize_text((string) hr_sa_hrdf_pick($trip, ['description'], '')),
+        'images'              => hr_sa_hrdf_normalize_url_list(hr_sa_hrdf_pick($trip, ['images', 'image'], [])),
+        'additional_property' => hr_sa_hrdf_to_array(hr_sa_hrdf_pick($trip, ['additional_property', 'additionalProperty'], [])),
+        'itinerary'           => hr_sa_hrdf_to_array(hr_sa_hrdf_pick($trip, ['itinerary', 'itinerary.steps', 'itinerarySteps'], [])),
+        'faq'                 => hr_sa_hrdf_to_array(hr_sa_hrdf_pick($trip, ['faq'], [])),
+        'vehicles'            => hr_sa_hrdf_to_array(hr_sa_hrdf_pick($trip, ['vehicles'], [])),
+        'reviews'             => hr_sa_hrdf_to_array(hr_sa_hrdf_pick($trip, ['reviews'], [])),
+        'aggregate_rating'    => $aggregate !== [] ? $aggregate : null,
+        'offers'              => hr_sa_hrdf_to_array(hr_sa_hrdf_pick($trip, ['offers'], [])),
+        'product'             => hr_sa_hrdf_force_array($sections['product'] ?? []),
+        'og'                  => hr_sa_hrdf_force_array($sections['og'] ?? []),
+        'twitter'             => hr_sa_hrdf_force_array($sections['twitter'] ?? []),
     ];
 
     return $cache[$post_id] = $payload;


### PR DESCRIPTION
## Summary
- normalize the batched HRDF trip payload via new helpers and reuse it for trip/site data
- update the shared context to hydrate OG/Twitter fields from the aggregated payload

## Testing
- php -l core/hrdf.php
- php -l core/context.php

------
https://chatgpt.com/codex/tasks/task_e_68df7f61504c8327aaef8d4ccd5c02a0